### PR TITLE
Porter YAML schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Visual Studio Code Porter Tools
 
 Build CNAB bundles with Porter
+
+## Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,10 @@
 
 import * as vscode from 'vscode';
 
-export function activate(context: vscode.ExtensionContext) {
+import { registerYamlSchema } from './yaml/yaml-schema';
+
+export async function activate(context: vscode.ExtensionContext) {
+    await registerYamlSchema();
 }
 
 export function deactivate() {

--- a/src/schema/json-schema.ts
+++ b/src/schema/json-schema.ts
@@ -19,7 +19,8 @@ interface JSONArraySchema extends JSONSchemaCommon {
 
 interface JSONObjectSchema extends JSONSchemaCommon {
     readonly type: "object";
-    readonly properties: { [key: string]: JSONSchema };
+    readonly properties?: { [key: string]: JSONSchema };
+    readonly $ref?: string;
     readonly additionalProperties?: boolean;  // technically incorrect but good enough for our use case
     readonly required?: string[];
     readonly oneOf?: any[];  // TODO: un-any-fy

--- a/src/schema/json-schema.ts
+++ b/src/schema/json-schema.ts
@@ -14,14 +14,14 @@ interface JSONArraySchema extends JSONSchemaCommon {
     readonly type: "array";
     readonly items: {
         readonly $ref: string;
-    };
+    } | JSONSchema;
 }
 
 interface JSONObjectSchema extends JSONSchemaCommon {
     readonly type: "object";
     readonly properties?: { [key: string]: JSONSchema };
     readonly $ref?: string;
-    readonly additionalProperties?: boolean;  // technically incorrect but good enough for our use case
+    readonly additionalProperties?: boolean | JSONSchema;
     readonly required?: string[];
     readonly oneOf?: any[];  // TODO: un-any-fy
 }

--- a/src/schema/json-schema.ts
+++ b/src/schema/json-schema.ts
@@ -1,0 +1,32 @@
+interface JSONRootSchema extends JSONObjectSchema {
+    readonly definitions: { [key: string]: JSONSchema };
+}
+
+interface JSONSchemaCommon {
+    readonly description?: string;
+}
+
+interface JSONStringSchema extends JSONSchemaCommon {
+    readonly type: "string";
+}
+
+interface JSONArraySchema extends JSONSchemaCommon {
+    readonly type: "array";
+    readonly items: {
+        readonly $ref: string;
+    };
+}
+
+interface JSONObjectSchema extends JSONSchemaCommon {
+    readonly type: "object";
+    readonly properties: { [key: string]: JSONSchema };
+    readonly additionalProperties?: boolean;  // technically incorrect but good enough for our use case
+    readonly required?: string[];
+    readonly oneOf?: any[];  // TODO: un-any-fy
+}
+
+interface JSONEnumSchema {
+    readonly enum: string[];
+}
+
+type JSONSchema = JSONStringSchema | JSONArraySchema | JSONObjectSchema | JSONEnumSchema;

--- a/src/schema/porter-base-schema.ts
+++ b/src/schema/porter-base-schema.ts
@@ -1,4 +1,4 @@
-export function porterBaseSchema(): JSONSchema {
+export function porterBaseSchema(): JSONRootSchema {
     const schema: JSONRootSchema = {
         description: "Porter bundle specification",
         type: "object",

--- a/src/schema/porter-base-schema.ts
+++ b/src/schema/porter-base-schema.ts
@@ -45,6 +45,12 @@ function porterRootProperties(): { [key: string]: JSONSchema } {
             items: {
                 $ref: "#/definitions/parameter"
             }
+        },
+        dependencies: {
+            type: "array",
+            items: {
+                $ref: "#/definitions/dependency"
+            }
         }
     };
 
@@ -102,6 +108,41 @@ function porterParameterSchema(): JSONSchema {
     };
 }
 
+function porterDependencySchema(): JSONSchema {
+    return {
+        type: "object",
+        properties: {
+            name: {
+                type: "string"
+            },
+            parameters: {
+                type: "object",
+                additionalProperties: {
+                    type: "string"
+                }
+            },
+            connections: {
+                type: "array",
+                items: {
+                    type: "object",
+                    properties: {
+                        source: {
+                            type: "string"
+                        },
+                        destination: {
+                            type: "string"
+                        }
+                    },
+                    required: ["source", "destination"],
+                    additionalProperties: false,
+                }
+            }
+        },
+        required: ["name"],
+        additionalProperties: false
+    };
+}
+
 function porterStepOutputSchema(): JSONSchema {
     return {
         type: "object",
@@ -122,6 +163,7 @@ function porterSchemaDefinitions(): { [key: string]: JSONSchema } {
         },
         credential: porterCredentialSchema(),
         parameter: porterParameterSchema(),
+        dependency: porterDependencySchema(),
         stepOutput: porterStepOutputSchema()
     };
 
@@ -142,7 +184,7 @@ function stepBaseSchema(): JSONSchema {
             outputs: {
                 type: "array",
                 items: {
-                    $ref: "#/definitions/stepoutput"
+                    $ref: "#/definitions/stepOutput"
                 }
             }
         },

--- a/src/schema/porter-base-schema.ts
+++ b/src/schema/porter-base-schema.ts
@@ -15,7 +15,7 @@ export function porterBaseSchema(): JSONRootSchema {
     return schema;
 }
 
-const PORTER_ACTION_IDS = ['install'];
+const PORTER_ACTION_IDS = ['install', 'uninstall'];
 
 function porterRootProperties(): { [key: string]: JSONSchema } {
     const properties: { [key: string]: JSONSchema } = {
@@ -102,13 +102,27 @@ function porterParameterSchema(): JSONSchema {
     };
 }
 
+function porterStepOutputSchema(): JSONSchema {
+    return {
+        type: "object",
+        properties: {
+            name: {
+                type: "string"
+            }
+        },
+        required: ["name"],
+        additionalProperties: true
+    };
+}
+
 function porterSchemaDefinitions(): { [key: string]: JSONSchema } {
     const definitions: { [key: string]: JSONSchema } = {
         mixinId: {
             enum: []
         },
         credential: porterCredentialSchema(),
-        parameter: porterParameterSchema()
+        parameter: porterParameterSchema(),
+        stepOutput: porterStepOutputSchema()
     };
 
     for (const action of PORTER_ACTION_IDS) {
@@ -124,6 +138,12 @@ function stepBaseSchema(): JSONSchema {
         properties: {
             description: {
                 type: "string"
+            },
+            outputs: {
+                type: "array",
+                items: {
+                    $ref: "#/definitions/stepoutput"
+                }
             }
         },
         additionalProperties: false,

--- a/src/schema/porter-base-schema.ts
+++ b/src/schema/porter-base-schema.ts
@@ -1,0 +1,101 @@
+export function porterBaseSchema(): JSONSchema {
+    const schema: JSONRootSchema = {
+        description: "Porter bundle specification",
+        type: "object",
+        properties: porterRootProperties(),
+        required: [
+            "name",
+            "version",
+            "invocationImage"
+        ],
+        additionalProperties: false,
+        definitions: porterSchemaDefinitions()
+    };
+
+    return schema;
+}
+
+const PORTER_ACTION_IDS = ['install'];
+
+function porterRootProperties(): { [key: string]: JSONSchema } {
+    const properties: { [key: string]: JSONSchema } = {
+        name: {
+            type: "string"
+        },
+        version: {
+            type: "string"
+        },
+        invocationImage: {
+            type: "string"
+        },
+        mixins: {
+            type: "array",
+            items: {
+                $ref: "#/definitions/mixinId"
+            }
+        },
+        parameters: {
+            type: "array",
+            items: {
+                $ref: "#/definitions/parameter"
+            }
+        }
+    };
+
+    for (const action of PORTER_ACTION_IDS) {
+        properties[action] = {
+            type: "array",
+            items: {
+                $ref: `#/definitions/${action}`
+            }
+        };
+    }
+
+    return properties;
+}
+
+function porterParameterSchema(): JSONSchema {
+    return {
+        type: "object",
+        properties: {
+            name: {
+                type: "string"
+            },
+            type: {
+                type: "string"
+            },
+            default: {
+                type: "string"
+            },
+        },
+        additionalProperties: false
+    };
+}
+
+function porterSchemaDefinitions(): { [key: string]: JSONSchema } {
+    const definitions: { [key: string]: JSONSchema } = {
+        mixinId: {
+            enum: []
+        },
+        parameter: porterParameterSchema()
+    };
+
+    for (const action of PORTER_ACTION_IDS) {
+        definitions[action] = stepBaseSchema();
+    }
+
+    return definitions;
+}
+
+function stepBaseSchema(): JSONSchema {
+    return {
+        type: "object",
+        properties: {
+            description: {
+                type: "string"
+            }
+        },
+        additionalProperties: false,
+        oneOf: []
+    };
+}

--- a/src/schema/porter-base-schema.ts
+++ b/src/schema/porter-base-schema.ts
@@ -34,6 +34,12 @@ function porterRootProperties(): { [key: string]: JSONSchema } {
                 $ref: "#/definitions/mixinId"
             }
         },
+        credentials: {
+            type: "array",
+            items: {
+                $ref: "#/definitions/credential"
+            }
+        },
         parameters: {
             type: "array",
             items: {
@@ -54,6 +60,29 @@ function porterRootProperties(): { [key: string]: JSONSchema } {
     return properties;
 }
 
+function porterCredentialSchema(): JSONSchema {
+    return {
+        type: "object",
+        properties: {
+            name: {
+                type: "string"
+            },
+            path: {
+                type: "string"
+            },
+            env: {
+                type: "string"
+            }
+        },
+        required: ["name"],
+        oneOf: [
+            { required: ["path"] },
+            { required: ["env"] }
+        ],
+        additionalProperties: false
+    };
+}
+
 function porterParameterSchema(): JSONSchema {
     return {
         type: "object",
@@ -62,12 +91,13 @@ function porterParameterSchema(): JSONSchema {
                 type: "string"
             },
             type: {
-                type: "string"
+                enum: ["int", "string", "boolean"]
             },
             default: {
                 type: "string"
             },
         },
+        required: ["name", "type"],
         additionalProperties: false
     };
 }
@@ -77,6 +107,7 @@ function porterSchemaDefinitions(): { [key: string]: JSONSchema } {
         mixinId: {
             enum: []
         },
+        credential: porterCredentialSchema(),
         parameter: porterParameterSchema()
     };
 

--- a/src/schema/porter-mixin-schema.ts
+++ b/src/schema/porter-mixin-schema.ts
@@ -1,0 +1,44 @@
+export function mixins(): string[] {
+    return ['helm'];
+}
+
+function helmMixinSchema(): { [key: string]: JSONSchema } {
+    // TODO: this is for testing - should be replaced by dynamic loading - and be more complete!
+    return {
+        install: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                chart: {
+                    type: "string"
+                }
+            },
+            additionalProperties: false
+        }
+    };
+}
+
+function porterMixinSchema(mixin: string): { [key: string]: JSONSchema } | undefined {
+    // TODO: replace with dynamic loading
+    if (mixin === 'helm') {
+        return helmMixinSchema();
+    }
+
+    return undefined;
+}
+
+export function rollInMixinSchema(schema: JSONRootSchema, mixin: string): void {
+    (schema.definitions.mixinId as JSONEnumSchema).enum.push(mixin);
+
+    const mixinSchema = porterMixinSchema(mixin);
+    if (mixinSchema) {
+        for (const verb in mixinSchema) {
+            const verbSchema = schema.definitions[verb] as JSONObjectSchema;
+            verbSchema.properties![mixin] = { type: "object", $ref: `#/definitions/${mixin}-${verb}` };
+            verbSchema.oneOf!.push({ required: [mixin] });
+            schema.definitions[`${mixin}-${verb}`] = mixinSchema[verb];
+        }
+    }
+}

--- a/src/schema/porter-mixin-schema.ts
+++ b/src/schema/porter-mixin-schema.ts
@@ -45,7 +45,6 @@ function execMixinSchema(): { [key: string]: JSONSchema } {
                 }
             },
             required: [
-                "name",
                 "command"
             ],
             additionalProperties: false

--- a/src/schema/porter-mixin-schema.ts
+++ b/src/schema/porter-mixin-schema.ts
@@ -1,5 +1,5 @@
 export function mixins(): string[] {
-    return ['helm'];
+    return ['helm', 'exec'];
 }
 
 function helmMixinSchema(): { [key: string]: JSONSchema } {
@@ -20,10 +20,50 @@ function helmMixinSchema(): { [key: string]: JSONSchema } {
     };
 }
 
+function execMixinSchema(): { [key: string]: JSONSchema } {
+    function execStepMixinSchema(): JSONSchema {
+        return {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                command: {
+                    type: "string"
+                },
+                arguments: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                parameters: {
+                    type: "object",
+                    additionalProperties: {
+                        type: "string"
+                    }
+                }
+            },
+            required: [
+                "name",
+                "command"
+            ],
+            additionalProperties: false
+        };
+    }
+
+    return {
+        install: execStepMixinSchema(),
+        uninstall: execStepMixinSchema()
+    };
+}
+
 function porterMixinSchema(mixin: string): { [key: string]: JSONSchema } | undefined {
     // TODO: replace with dynamic loading
     if (mixin === 'helm') {
         return helmMixinSchema();
+    } else if (mixin === 'exec') {
+        return execMixinSchema();
     }
 
     return undefined;

--- a/src/utils/errorable.ts
+++ b/src/utils/errorable.ts
@@ -1,0 +1,26 @@
+export interface Succeeded<T> {
+    readonly succeeded: true;
+    readonly result: T;
+}
+
+export interface Failed {
+    readonly succeeded: false;
+    readonly error: string[];
+}
+
+export type Errorable<T> = Succeeded<T> | Failed;
+
+export function succeeded<T>(e: Errorable<T>): e is Succeeded<T> {
+    return e.succeeded;
+}
+
+export function failed<T>(e: Errorable<T>): e is Failed {
+    return !e.succeeded;
+}
+
+export function map<T, U>(e: Errorable<T>, fn: (t: T) => U): Errorable<U> {
+    if (failed(e)) {
+        return { succeeded: false, error: e.error };
+    }
+    return { succeeded: true, result: fn(e.result) };
+}

--- a/src/yaml/yaml-extension.ts
+++ b/src/yaml/yaml-extension.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { Errorable } from '../utils/errorable';
+
+const VSCODE_YAML_EXTENSION_ID = 'redhat.vscode-yaml';
+
+export interface YamlExtension {
+    registerContributor(
+        schema: string,
+        requestSchema: (resource: string) => string | undefined,
+        requestSchemaContent: (uri: string) => string | undefined
+    ): void;
+}
+
+export async function activateYamlExtension(): Promise<Errorable<YamlExtension>> {
+    const extension = vscode.extensions.getExtension(VSCODE_YAML_EXTENSION_ID);
+    if (!extension) {
+        return { succeeded: false, error: ['Please install \'YAML Support by Red Hat\' via the Extensions pane.'] };
+    }
+
+    const extensionAPI = await extension.activate();
+    if (!extensionAPI || !extensionAPI.registerContributor) {
+        return { succeeded: false, error: ['The installed Red Hat YAML extension doesn\'t support Porter intellisense. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.'] };
+    }
+
+    return { succeeded: true, result: extensionAPI };
+}

--- a/src/yaml/yaml-schema.ts
+++ b/src/yaml/yaml-schema.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+import { activateYamlExtension } from "./yaml-extension";
+import { failed } from '../utils/errorable';
+import { porterBaseSchema } from '../schema/porter-base-schema';
+
+const PORTER_SCHEMA = 'porter';
+
+export async function registerYamlSchema(): Promise<void> {
+    const yamlPlugin = await activateYamlExtension();
+    if (failed(yamlPlugin)) {
+        vscode.window.showWarningMessage(yamlPlugin.error[0]);
+        return;
+    }
+
+    yamlPlugin.result.registerContributor(PORTER_SCHEMA, onRequestSchemaURI, onRequestSchemaContent);
+}
+
+function onRequestSchemaURI(resource: string): string | undefined {
+    if (resource.endsWith('porter.yaml')) {
+        return `${PORTER_SCHEMA}://schema/porter`;
+    }
+    return undefined;
+}
+
+function onRequestSchemaContent(schemaUri: string): string | undefined {
+    const parsedUri = vscode.Uri.parse(schemaUri);
+    if (parsedUri.scheme !== PORTER_SCHEMA) {
+        return undefined;
+    }
+    if (!parsedUri.path || !parsedUri.path.startsWith('/')) {
+        return undefined;
+    }
+
+    const schema = porterBaseSchema();
+
+    const schemaJSON = JSON.stringify(schema, undefined, 2);
+    console.log(schemaJSON);
+    return schemaJSON;
+}

--- a/src/yaml/yaml-schema.ts
+++ b/src/yaml/yaml-schema.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { activateYamlExtension } from "./yaml-extension";
 import { failed } from '../utils/errorable';
 import { porterBaseSchema } from '../schema/porter-base-schema';
+import { mixins, rollInMixinSchema } from '../schema/porter-mixin-schema';
 
 const PORTER_SCHEMA = 'porter';
 
@@ -32,6 +33,10 @@ function onRequestSchemaContent(schemaUri: string): string | undefined {
     }
 
     const schema = porterBaseSchema();
+
+    for (const mixin of mixins()) {
+        rollInMixinSchema(schema, mixin);
+    }
 
     const schemaJSON = JSON.stringify(schema, undefined, 2);
     console.log(schemaJSON);


### PR DESCRIPTION
This demonstrates the base Porter schema and outlines how mixin schemas would be mixed into that.  The implementation of loading the mixin schemas is currently faked, as mixins cannot report this information by themselves, and in the Helm case the schema is a stub; but hopefully it proves we can have this dynamic validation.

Again as an interim, we associate this schema with `**/*porter.yaml` files - longer term we should work out a suitable convention.