### PR TITLE
Do best-effort intellisense on files open at activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import * as porter from './porter/porter';
 import { selectWorkspaceFolder, longRunning, showPorterResult } from './utils/host';
 import { succeeded, failed } from './utils/errorable';
 import * as shell from './utils/shell';
-import { registerYamlSchema } from './yaml/yaml-schema';
+import { registerYamlSchema, updateYamlSchema } from './yaml/yaml-schema';
 import { promptForCredentials } from './utils/credentials';
 import { suggestName, folderSelection, displayName, manifest } from './utils/bundleselection';
 import { promptForParameters } from './utils/parameters';
@@ -22,7 +22,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(...subscriptions);
 
-    await registerYamlSchema();
+    await registerYamlSchema(context);
+    updateYamlSchema(context);  // runs in background - do not wait for this to finish activation
 }
 
 export function deactivate() {

--- a/src/yaml/yaml-schema.ts
+++ b/src/yaml/yaml-schema.ts
@@ -28,7 +28,10 @@ export async function registerYamlSchema(extensionContext: vscode.ExtensionConte
 export async function updateYamlSchema(extensionContext: vscode.ExtensionContext): Promise<void> {
     const schema = await fetchSchema();
     if (failed(schema)) {
-        vscode.window.showWarningMessage(`Error loading Porter schema. Porter intellisense will not be available.\n\nDetails: ${schema.error[0]}`);
+        const message = schemaJSON ?
+            `Error checking for Porter schema updates. Porter intellisense may be out of date.\n\nDetails: ${schema.error[0]}` :
+            `Error loading Porter schema. Porter intellisense will not be available.\n\nDetails: ${schema.error[0]}`;
+        await vscode.window.showWarningMessage(message);
         return;
     }
 

--- a/src/yaml/yaml-schema.ts
+++ b/src/yaml/yaml-schema.ts
@@ -6,21 +6,15 @@ import { shell } from '../utils/shell';
 import { longRunning } from '../utils/host';
 
 const PORTER_SCHEMA = 'porter';
+const LAST_SCHEMA_CACHE_KEY = 'last-porter-yaml-schema';
 
 let schemaJSON: string | undefined = undefined;
 
-export async function registerYamlSchema(): Promise<void> {
+export async function registerYamlSchema(extensionContext: vscode.ExtensionContext): Promise<void> {
     // The schema request callback is synchronous, so we need to make sure
-    // the schema is pre-loaded ready for it.
-    const schema = await longRunning('Loading porter.yaml schema...', () =>
-        porter.schema(shell)
-    );
-    if (failed(schema)) {
-        vscode.window.showWarningMessage(`Error loading Porter schema. Porter intellisense will not be available.\n\nDetails: ${schema.error[0]}`);
-        return;
-    }
-
-    schemaJSON = schema.result;
+    // the schema is pre-loaded ready for it.  We will start with a best-effort
+    // but this may get updated later on, once `porter schema` has completed.
+    schemaJSON = extensionContext.globalState.get<string>(LAST_SCHEMA_CACHE_KEY);
 
     const yamlPlugin = await activateYamlExtension();
     if (failed(yamlPlugin)) {
@@ -29,6 +23,22 @@ export async function registerYamlSchema(): Promise<void> {
     }
 
     yamlPlugin.result.registerContributor(PORTER_SCHEMA, onRequestSchemaURI, onRequestSchemaContent);
+}
+
+export async function updateYamlSchema(extensionContext: vscode.ExtensionContext): Promise<void> {
+    const action = schemaJSON ? 'Updating' : 'Loading';
+    const schema = await longRunning(`${action} porter.yaml schema...`, () =>
+        porter.schema(shell)
+    );
+    if (failed(schema)) {
+        vscode.window.showWarningMessage(`Error loading Porter schema. Porter intellisense will not be available.\n\nDetails: ${schema.error[0]}`);
+        return;
+    }
+
+    if (schema.result && (schema.result !== schemaJSON)) {
+        schemaJSON = schema.result;
+        extensionContext.globalState.update(LAST_SCHEMA_CACHE_KEY, schemaJSON);
+    }
 }
 
 function onRequestSchemaURI(resource: string): string | undefined {


### PR DESCRIPTION
We currently have a limitation where RH YAML requires the schema to be available immediately when requested, but we need to perform an async invocation of Porter to get the schema.  This means that for any `porter.yaml` files that are open before the async invocation completes, we have no intellisense - and RH YAML doesn't yet allow us to apply the schema once we have it, so the user gets no intellisense until they close and reopen the file.

We can't rely on a cache to fix this, because the Porter schema depends on what mixins are in play, so it's hard to construct a practical cache key for all combinations of versions and mixins.

What we can do, though, is cache the last Porter schema we used, and use that as a best-effort schema for those initial files.  It may not be quite correct, but hopefully won't be too far off.  This allows initial files to get what will hopefully be reasonably accurate intellisense, and to get it promptly, though if the schema has changed since it was cached then users still need to close and reopen to pick up the new schema.

This PR does that.