### PR TITLE
Porter debug phase 1 - parameters and credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,11 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "await-notify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+            "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
+        },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2074,6 +2079,20 @@
                 "vinyl-fs": "^3.0.3",
                 "vinyl-source-stream": "^1.1.0"
             }
+        },
+        "vscode-debugadapter": {
+            "version": "1.37.1",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.37.1.tgz",
+            "integrity": "sha512-g/xNsUdkrd0DifaoRJ4+wypSMsMbK47fGpetpmIOnOQiDFjtYKvqxsgyUZ4BOj2jKP2Xa40B4YXfUUJpqreWJg==",
+            "requires": {
+                "mkdirp": "^0.5.1",
+                "vscode-debugprotocol": "1.37.0"
+            }
+        },
+        "vscode-debugprotocol": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.37.0.tgz",
+            "integrity": "sha512-ppZLEBbFRVNsK0YpfgFi/x2CDyihx0F+UpdKmgeJcvi05UgSXYdO0n9sDVYwoGvvYQPvlpDQeWuY0nloOC4mPA=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2105,6 +2105,11 @@
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
         },
+        "yaml-ast-parser": {
+            "version": "0.0.43",
+            "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+            "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
+        },
         "yauzl": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,9 +1874,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+            "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
             "dev": true
         },
         "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "onCommand:porter.createProject",
         "onCommand:porter.build",
         "onCommand:porter.install",
+        "onDebug",
         "onLanguage:yaml"
     ],
     "main": "./out/extension",
@@ -55,7 +56,56 @@
                     }
                 }
             }
-        }
+        },
+        "debuggers": [
+            {
+                "type": "porter",
+                "label": "Porter",
+                "program": "./out/debugger/debug-adapter.js",
+                "runtime": "node",
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [
+                            "porter-file"
+                        ],
+                        "properties": {
+                            "porter-file": {
+                                "type": "string",
+                                "description": "Absolute path to porter.yaml.",
+                                "default": "${workspaceFolder}/porter.yaml"
+                            },
+                            "stopOnEntry": {
+                                "type": "boolean",
+                                "description": "Automatically stop after launch.",
+                                "default": true
+                            }
+                        }
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "type": "porter",
+                        "request": "launch",
+                        "name": "Porter Install",
+                        "porter-file": "${workspaceFolder}/porter.yaml",
+                        "stopOnEntry": true
+                    }
+                ],
+                "configurationSnippets": [
+                    {
+                        "label": "Porter Debug: Install",
+                        "description": "A new configuration for debugging a Porter bundle.",
+                        "body": {
+                            "type": "porter",
+                            "request": "launch",
+                            "name": "Ask for file name",
+                            "porter-file": "^\"\\${workspaceFolder}/porter.yaml\"",
+                            "stopOnEntry": true
+                        }
+                    }
+                ]
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
@@ -69,10 +119,12 @@
     ],
     "dependencies": {
         "@types/shelljs": "^0.8.1",
+        "await-notify": "1.0.1",
         "cnabjs": "0.0.5",
         "mkdirp": "^0.5.1",
         "shelljs": "^0.8.3",
-        "tmp": "^0.0.33"
+        "tmp": "^0.0.33",
+        "vscode-debugadapter": "^1.37.1"
     },
     "devDependencies": {
         "@types/mkdirp": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
                 }
             }
         },
+        "breakpoints": [
+            {
+                "language": "yaml"
+            }
+        ],
         "debuggers": [
             {
                 "type": "porter",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,19 @@
                                 "type": "boolean",
                                 "description": "Automatically stop after launch.",
                                 "default": true
+                            },
+                            "installInputs": {
+                                "type": "object",
+                                "description": "The install command inputs with which to debug (suppresses prompting for inputs)",
+                                "default": null,
+                                "properties": {
+                                    "parameters": {
+                                        "type": "object"
+                                    },
+                                    "credentialSet": {
+                                        "type": "string"
+                                    }
+                                }
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
                         "properties": {
                             "porter-file": {
                                 "type": "string",
-                                "description": "Absolute path to porter.yaml.",
+                                "description": "Absolute path to porter.yaml",
                                 "default": "${workspaceFolder}/porter.yaml"
                             },
                             "stopOnEntry": {
                                 "type": "boolean",
-                                "description": "Automatically stop after launch.",
+                                "description": "Automatically stop after launch",
                                 "default": true
                             },
                             "installInputs": {
@@ -112,15 +112,16 @@
                 "configurationSnippets": [
                     {
                         "label": "Porter Debug: Install",
-                        "description": "A new configuration for debugging a Porter bundle.",
+                        "description": "A new configuration for debugging a Porter bundle install action",
                         "body": {
                             "type": "porter",
                             "request": "launch",
-                            "name": "Ask for file name",
+                            "name": "Porter Install",
                             "porter-file": "^\"\\${workspaceFolder}/porter.yaml\"",
                             "stopOnEntry": true
                         }
                     }
+
                 ]
             }
         ]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "onCommand:porter.createProject",
         "onCommand:porter.build",
         "onCommand:porter.install",
-        "onDebug",
+        "onDebugResolve:porter",
         "onLanguage:yaml"
     ],
     "main": "./out/extension",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
         "@types/node": "10.12.25",
         "@types/tmp": "0.0.33",
         "tslint": "^5.8.0",
-        "typescript": "^2.6.1",
+        "typescript": "^3.6.4",
         "vscode": "^1.1.6"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
         "mkdirp": "^0.5.1",
         "shelljs": "^0.8.3",
         "tmp": "^0.0.33",
-        "vscode-debugadapter": "^1.37.1"
+        "vscode-debugadapter": "^1.37.1",
+        "yaml-ast-parser": "0.0.43"
     },
     "devDependencies": {
         "@types/mkdirp": "^0.5.2",

--- a/src/debugger/ast.ts
+++ b/src/debugger/ast.ts
@@ -1,0 +1,127 @@
+import * as yaml from 'yaml-ast-parser';
+import { YAMLSequence } from 'yaml-ast-parser';
+import { definedOf } from '../utils/array';
+
+export interface PorterManifestYAML {
+    readonly actions: ReadonlyArray<PorterActionYAML>;
+}
+
+export interface PorterActionYAML {
+    readonly name: string;
+    readonly steps: ReadonlyArray<PorterStepYAML>;
+}
+
+export interface PorterStepYAML {
+    readonly startLine: number;
+    readonly outputs: ReadonlyArray<PorterOutputYAML>;
+}
+
+export interface PorterOutputYAML {
+    readonly name: string;
+}
+
+const nonStepArrays = ['mixins', 'parameters', 'credentials'];
+
+export function parse(yamlText: string): PorterManifestYAML | undefined {
+    return new PorterManifestASTParser(yamlText).parse();
+}
+
+class PorterManifestASTParser {
+    private readonly lineStartPositions: ReadonlyArray<number>;
+
+    constructor(private readonly yamlText: string) {
+        this.lineStartPositions = lineStartPositions(yamlText);
+    }
+
+    public parse(): PorterManifestYAML | undefined {
+        const ast = safeLoadOrGTFO(this.yamlText);
+        if (!ast) {
+            return undefined;
+        }
+
+        if (ast.kind !== yaml.Kind.MAP) {
+            return undefined;
+        }
+
+        const mappings = (ast as yaml.YamlMap).mappings;
+        const actionMappings = mappings.filter((m) => m.key && m.value && m.value.kind === yaml.Kind.SEQ && nonStepArrays.indexOf(m.key.value) < 0);  // TODO: better heuristics?
+
+        return {
+            actions: actionMappings.map((m) => this.asActionAST(m))
+        };
+    }
+
+    private asActionAST(m: yaml.YAMLMapping): PorterActionYAML {
+        const actionName = m.key.value;
+        const steps = (m.value as yaml.YAMLSequence).items;
+        const stepMappings = steps.filter((s) => s.kind === yaml.Kind.MAP).map((s) => s as yaml.YamlMap);
+        const steppaz = stepMappings.map((sm) => this.asStepAST(sm));
+        return { name: actionName, steps: definedOf(...steppaz) };
+    }
+
+    private asStepAST(step: yaml.YamlMap): PorterStepYAML | undefined {
+        const stepMap = step.mappings;
+        if (stepMap.length !== 1) {
+            return undefined;
+        }
+        const stepData = stepMap[0].value;
+        if (stepData.kind !== yaml.Kind.MAP) {
+            return undefined;
+        }
+        const stepDataMappings = (stepData as yaml.YamlMap).mappings;
+        const outputSection = stepDataMappings.find((dm) => dm.key.value === 'outputs');
+        if (!outputSection) {
+            return { startLine: this.lineOf(step.startPosition), outputs: [] };
+        }
+        if (outputSection.value.kind !== yaml.Kind.SEQ) {
+            return undefined;
+        }
+        const outputEntries = (outputSection.value as YAMLSequence).items.filter((o) => o.kind === yaml.Kind.MAP).map((o) => o as yaml.YamlMap);
+        return {
+            startLine: this.lineOf(step.startPosition),
+            outputs: definedOf(...outputEntries.map((o) => this.asOutputAST(o)))
+        };
+    }
+
+    private asOutputAST(o: yaml.YamlMap): PorterOutputYAML | undefined {
+        const nameMapping = o.mappings.find((m) => m.key.value === 'name');
+        if (!nameMapping) {
+            return undefined;
+        }
+        return { name: nameMapping.value.value };
+    }
+
+    private lineOf(position: number): number {
+        for (let ln = 0; ln < this.lineStartPositions.length; ++ln) {
+            if (position < this.lineStartPositions[ln]) {
+                return ln - 1;
+            }
+        }
+        return this.lineStartPositions.length;
+    }
+}
+
+function safeLoadOrGTFO(yamlText: string): yaml.YAMLNode | undefined {
+    try {
+        return yaml.safeLoad(yamlText);
+    } catch {
+        return undefined;
+    }
+}
+
+function lineStartPositions(text: string): ReadonlyArray<number> {
+    const positions = Array.of<number>();
+    for (const pos of lineStartPositionsImpl(text)) {
+        positions.push(pos);
+    }
+    return positions;
+}
+
+function* lineStartPositionsImpl(text: string) {
+    const lines = text.split('\n');
+    let pos = 0;
+    for (const line of lines) {
+        yield pos;
+        pos += line.length + 1;
+    }
+}

--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -32,7 +32,7 @@ async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefi
         }
     }
 
-    const folderPath = editor ? path.dirname(editor.document.uri.fsPath) : await findPorterManifestDirectory();
+    const folderPath = folder ? folder.uri.fsPath : await findPorterManifestDirectory();
 
     if (!config['porter-file'] || !folderPath) {
         await vscode.window.showInformationMessage("Cannot find a Porter file to debug");
@@ -78,6 +78,11 @@ async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefi
 }
 
 async function findPorterManifestDirectory(): Promise<string | undefined> {
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.uri.fsPath.indexOf('porter.yaml') >= 0) {
+        return path.dirname(editor.document.uri.fsPath);
+    }
+
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
         return undefined;

--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { InstallInputs } from './session-parameters';
+import { InstallInputs } from './session-protocol';
 import { folderSelection, suggestName, displayName, manifest } from '../utils/bundleselection';
 import { formatHyphenated } from '../utils/date';
 import { longRunning } from '../utils/host';

--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+export class PorterInstallConfigurationProvider implements vscode.DebugConfigurationProvider {
+
+    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+
+        // if launch.json is missing or empty
+        if (!config.type && !config.request && !config.name) {
+            const editor = vscode.window.activeTextEditor;
+            if (editor && editor.document.languageId === 'yaml' && editor.document.uri.fsPath.indexOf('porter.yaml') >= 0) {
+                config.type = 'porter';
+                config.name = 'Launch';
+                config.request = 'launch';
+                config['porter-file'] = '${file}';
+                config.stopOnEntry = true;
+            }
+        }
+
+        if (!config['porter-file']) {
+            return vscode.window.showInformationMessage("Cannot find a Porter file to debug").then((_) => {
+                return undefined;	// abort launch
+            });
+        }
+
+        return config;
+    }
+}

--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -3,25 +3,35 @@ import * as vscode from 'vscode';
 export class PorterInstallConfigurationProvider implements vscode.DebugConfigurationProvider {
 
     resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-
-        // if launch.json is missing or empty
-        if (!config.type && !config.request && !config.name) {
-            const editor = vscode.window.activeTextEditor;
-            if (editor && editor.document.languageId === 'yaml' && editor.document.uri.fsPath.indexOf('porter.yaml') >= 0) {
-                config.type = 'porter';
-                config.name = 'Launch';
-                config.request = 'launch';
-                config['porter-file'] = '${file}';
-                config.stopOnEntry = true;
-            }
-        }
-
-        if (!config['porter-file']) {
-            return vscode.window.showInformationMessage("Cannot find a Porter file to debug").then((_) => {
-                return undefined;	// abort launch
-            });
-        }
-
-        return config;
+        return resolveDebugConfiguration(folder, config, token);
     }
+}
+
+async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
+
+    // if launch.json is missing or empty
+    if (!config.type && !config.request && !config.name) {
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.languageId === 'yaml' && editor.document.uri.fsPath.indexOf('porter.yaml') >= 0) {
+            config.type = 'porter';
+            config.name = 'Launch';
+            config.request = 'launch';
+            config['porter-file'] = '${file}';
+            config.stopOnEntry = true;
+        }
+    }
+
+    if (!config['porter-file']) {
+        await vscode.window.showInformationMessage("Cannot find a Porter file to debug");
+        return undefined;	// abort launch
+    }
+
+    const porterInputs = await vscode.window.showInputBox({ prompt: "Enter parameters and credentials (no, this is not a real UI)" });
+    if (!porterInputs) {
+        return undefined;
+    }
+
+    config.porterInputs = porterInputs;
+
+    return config;
 }

--- a/src/debugger/debug-adapter.ts
+++ b/src/debugger/debug-adapter.ts
@@ -1,0 +1,3 @@
+import { PorterInstallDebugSession } from "./install-session";
+
+PorterInstallDebugSession.run(PorterInstallDebugSession);

--- a/src/debugger/descriptor-factory.ts
+++ b/src/debugger/descriptor-factory.ts
@@ -1,0 +1,29 @@
+import * as net from 'net';
+import * as vscode from 'vscode';
+import { PorterInstallDebugSession } from './install-session';
+
+export class PorterInstallDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+
+    private server?: net.Server;
+
+    createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+
+        if (!this.server) {
+            // start listening on a random port
+            this.server = net.createServer((socket) => {
+                const session = new PorterInstallDebugSession();
+                session.setRunAsServer(true);
+                session.start(<NodeJS.ReadableStream>socket, socket);
+            }).listen(0);
+        }
+
+        return new vscode.DebugAdapterServer((<net.AddressInfo>this.server.address()).port);
+    }
+
+    dispose() {
+        if (this.server) {
+            this.server.close();
+            this.server = undefined;
+        }
+    }
+}

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -54,8 +54,6 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         response.body = response.body || {};
         response.body.supportsConfigurationDoneRequest = true;
 
-        // make VS Code to use 'evaluate' when hovering over source
-        // TODO: what does this mean?
         response.body.supportsEvaluateForHovers = true;
 
         response.body.supportsStepBack = false;
@@ -63,8 +61,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         response.body.supportsCompletionsRequest = true;
         response.body.completionTriggerCharacters = [ "." ];
 
-        // TODO: should this be a thing?
-        response.body.supportsCancelRequest = true;
+        response.body.supportsCancelRequest = false;
 
         response.body.supportsBreakpointLocationsRequest = false;
 
@@ -79,8 +76,6 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
     }
 
     protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
-
-        // logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
         logger.setup(Logger.LogLevel.Stop, false);
 
         await this.configurationDone.wait(1000);

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -74,7 +74,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         response.body.supportsStepBack = false;
         response.body.supportsDataBreakpoints = false;
         response.body.supportsCompletionsRequest = true;
-        response.body.completionTriggerCharacters = [ ".", "b" ];
+        response.body.completionTriggerCharacters = [ ".", EXPRESSION_INITIAL_PREFIX ];
 
         response.body.supportsCancelRequest = false;
 

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -7,7 +7,7 @@ import {
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { basename } from 'path';
 import { PorterInstallRuntime } from './runtime';
-import { InstallInputs, VariableInfo } from './session-parameters';
+import { InstallInputs, VariableInfo, EVENT_STOP_ON_ENTRY, EVENT_STOP_ON_STEP, EVENT_OUTPUT, EVENT_END } from './session-protocol';
 import { Errorable } from '../utils/errorable';
 
 const { Subject } = require('await-notify');
@@ -46,20 +46,20 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
 
         this.runtime = new PorterInstallRuntime();
 
-        this.runtime.on('stopOnEntry', () => {
+        this.runtime.on(EVENT_STOP_ON_ENTRY, () => {
             this.sendEvent(new StoppedEvent('entry', FAKE_THREAD_ID));
         });
-        this.runtime.on('stopOnStep', () => {
+        this.runtime.on(EVENT_STOP_ON_STEP, () => {
             this.sendEvent(new StoppedEvent('step', FAKE_THREAD_ID));
         });
-        this.runtime.on('output', (text: string, filePath: string, line: number, column: number) => {
+        this.runtime.on(EVENT_OUTPUT, (text: string, filePath: string, line: number, column: number) => {
             const e: DebugProtocol.OutputEvent = new OutputEvent(`${text}\n`);
             e.body.source = this.createSource(filePath);
             e.body.line = this.convertDebuggerLineToClient(line);
             e.body.column = this.convertDebuggerColumnToClient(column);
             this.sendEvent(e);
         });
-        this.runtime.on('end', () => {
+        this.runtime.on(EVENT_END, () => {
             this.sendEvent(new TerminatedEvent());
         });
     }

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -1,0 +1,136 @@
+import {
+    Logger, logger,
+    LoggingDebugSession,
+    InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent,
+    Scope, Source, StackFrame, Thread, Handles
+} from 'vscode-debugadapter';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { basename } from 'path';
+import { PorterInstallRuntime } from './runtime';
+
+const { Subject } = require('await-notify');
+
+interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+    'porter-file': string;
+    stopOnEntry?: boolean;
+}
+
+const FAKE_THREAD_ID = 1;
+
+export class PorterInstallDebugSession extends LoggingDebugSession {
+    private readonly runtime: PorterInstallRuntime;
+    private readonly configurationDone = new Subject();
+    private readonly variableHandles = new Handles<string>();
+
+    constructor() {
+        super();
+
+        this.setDebuggerLinesStartAt1(false);
+        this.setDebuggerColumnsStartAt1(false);
+
+        this.runtime = new PorterInstallRuntime();
+
+        this.runtime.on('stopOnEntry', () => {
+            this.sendEvent(new StoppedEvent('entry', FAKE_THREAD_ID));
+        });
+        this.runtime.on('stopOnStep', () => {
+            this.sendEvent(new StoppedEvent('step', FAKE_THREAD_ID));
+        });
+        this.runtime.on('output', (text: string, filePath: string, line: number, column: number) => {
+            const e: DebugProtocol.OutputEvent = new OutputEvent(`${text}\n`);
+            e.body.source = this.createSource(filePath);
+            e.body.line = this.convertDebuggerLineToClient(line);
+            e.body.column = this.convertDebuggerColumnToClient(column);
+            this.sendEvent(e);
+        });
+        this.runtime.on('end', () => {
+            this.sendEvent(new TerminatedEvent());
+        });
+    }
+
+    protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+        response.body = response.body || {};
+        response.body.supportsConfigurationDoneRequest = true;
+
+        // make VS Code to use 'evaluate' when hovering over source
+        // TODO: what does this mean?
+        response.body.supportsEvaluateForHovers = true;
+
+        response.body.supportsStepBack = false;
+        response.body.supportsDataBreakpoints = false;
+        response.body.supportsCompletionsRequest = false;
+        // response.body.completionTriggerCharacters = [ ".", "[" ];
+
+        // TODO: should this be a thing?
+        response.body.supportsCancelRequest = false;
+
+        response.body.supportsBreakpointLocationsRequest = false;
+
+        this.sendResponse(response);
+        this.sendEvent(new InitializedEvent());
+    }
+
+    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
+        super.configurationDoneRequest(response, args);
+
+        // notify the launchRequest that configuration has finished
+        this.configurationDone.notify();
+    }
+
+    protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
+
+        // logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
+        logger.setup(Logger.LogLevel.Stop, false);
+
+        await this.configurationDone.wait(1000);
+        this.runtime.start(args['porter-file'], !!args.stopOnEntry);
+
+        this.sendResponse(response);
+    }
+
+    protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+        response.body = {
+            threads: [
+                new Thread(FAKE_THREAD_ID, `Thread ${FAKE_THREAD_ID}`)
+            ]
+        };
+        this.sendResponse(response);
+    }
+
+    protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): void {
+        const startFrame = typeof args.startFrame === 'number' ? args.startFrame : 0;
+        const maxLevels = typeof args.levels === 'number' ? args.levels : 1000;
+        const endFrame = startFrame + maxLevels;
+
+        const stack = this.runtime.stack(startFrame, endFrame);
+
+        response.body = {
+            stackFrames: stack.frames.map((f: any) => new StackFrame(f.index, f.name, this.createSource(f.file), this.convertDebuggerLineToClient(f.line))),
+            totalFrames: stack.count
+        };
+        this.sendResponse(response);
+    }
+
+    protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments): void {
+        response.body = {
+            scopes: [
+                new Scope("Bundle", this.variableHandles.create("bundle"), true)
+            ]
+        };
+        this.sendResponse(response);
+    }
+
+    protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments): void {
+        this.runtime.continue();
+        this.sendResponse(response);
+    }
+
+    protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments): void {
+        this.runtime.step();
+        this.sendResponse(response);
+    }
+
+    private createSource(filePath: string): Source {
+        return new Source(basename(filePath), this.convertDebuggerPathToClient(filePath), undefined, undefined, 'porter-adapter-data');
+    }
+}

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -148,6 +148,8 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
 
     protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
         // TODO: this will need attention
+        // NOTE: if we return response.success = false, then no hover tip is shown.  So unfortunately
+        // we have to return a body containing an error message.
         if (args.expression && args.expression.startsWith('bundle.parameters.')) {
             const parameterName = args.expression.substring('bundle.parameters.'.length);
             const variables = this.runtime.getParameters();
@@ -155,8 +157,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
             if (variable) {
                 response.body = { result: variable.value, variablesReference: 0 };
             } else {
-                response.success = false;
-                response.message = `${args.expression} not defined`;
+                response.body = { result: `${args.expression} not defined`, variablesReference: 0 };
             }
         } else if (args.expression && args.expression.startsWith('bundle.credentials.')) {
             const credentialName = args.expression.substring('bundle.credentials.'.length);
@@ -167,16 +168,17 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
                 if (credentialValue.succeeded) {
                     response.body = { result: credentialValue.result, variablesReference: 0 };
                 } else {
-                    response.success = false;
-                    response.message = `evaluation failed: ${credentialValue.error[0]}`;
-                    }
+                    response.body = { result: `evaluation failed: ${credentialValue.error[0]}`, variablesReference: 0 };
+                }
             } else {
-                response.success = false;
-                response.message = `${args.expression} not defined`;
+                response.body = { result: `${args.expression} not defined`, variablesReference: 0 };
             }
+        } else if (args.expression && args.expression.startsWith('bundle.outputs.')) {
+            // TODO: do it
+            response.body = { result: `NOT DONE YET`, variablesReference: 0 };
         } else {
             response.success = false;
-            response.message = `${args.expression} not defined`;
+            response.body = { result: `${args.expression} not defined`, variablesReference: 0 };
         }
         this.sendResponse(response);
     }

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -16,6 +16,7 @@ const PARAMETERS_HANDLE = 'parameters';
 const CREDENTIALS_HANDLE = 'credentials';
 const STEP_OUTPUTS_HANDLE = 'step-outputs';
 
+const EXPRESSION_INITIAL_PREFIX = 'b';
 const REF_EXPRESSION_PREFIX = 'bundle.';
 const PARAMETER_REF_KEY = 'parameters';
 const CREDENTIAL_REF_KEY = 'credentials';
@@ -73,7 +74,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         response.body.supportsStepBack = false;
         response.body.supportsDataBreakpoints = false;
         response.body.supportsCompletionsRequest = true;
-        response.body.completionTriggerCharacters = [ "." ];
+        response.body.completionTriggerCharacters = [ ".", "b" ];
 
         response.body.supportsCancelRequest = false;
 
@@ -243,6 +244,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
 
     private async getCompletions(prefixText: string): Promise<ReadonlyArray<string> | undefined> {
         switch (prefixText) {
+            case EXPRESSION_INITIAL_PREFIX: return ['bundle'];
             case REF_EXPRESSION_PREFIX: return ALL_REF_KEYS;
             case PARAMETER_REF_PREFIX: return this.runtime.getParameters().map((v) => v.name);
             case CREDENTIAL_REF_PREFIX: return (await this.runtime.getCredentials()).map((c) => c.name);

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -7,13 +7,14 @@ import {
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { basename } from 'path';
 import { PorterInstallRuntime } from './runtime';
+import { InstallInputs } from './session-parameters';
 
 const { Subject } = require('await-notify');
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     'porter-file': string;
     stopOnEntry?: boolean;
-    porterInputs: string;
+    installInputs: InstallInputs;
 }
 
 const FAKE_THREAD_ID = 1;
@@ -83,7 +84,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         logger.setup(Logger.LogLevel.Stop, false);
 
         await this.configurationDone.wait(1000);
-        this.runtime.start(args['porter-file'], !!args.stopOnEntry, args.porterInputs);
+        this.runtime.start(args['porter-file'], !!args.stopOnEntry, args.installInputs);
 
         this.sendResponse(response);
     }

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -1,7 +1,7 @@
 import {
     Logger, logger,
     LoggingDebugSession,
-    InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent,
+    TerminatedEvent, StoppedEvent, OutputEvent,
     Scope, Source, StackFrame, Thread, Handles
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
@@ -13,6 +13,7 @@ const { Subject } = require('await-notify');
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     'porter-file': string;
     stopOnEntry?: boolean;
+    porterInputs: string;
 }
 
 const FAKE_THREAD_ID = 1;
@@ -62,12 +63,11 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         // response.body.completionTriggerCharacters = [ ".", "[" ];
 
         // TODO: should this be a thing?
-        response.body.supportsCancelRequest = false;
+        response.body.supportsCancelRequest = true;
 
         response.body.supportsBreakpointLocationsRequest = false;
 
         this.sendResponse(response);
-        this.sendEvent(new InitializedEvent());
     }
 
     protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
@@ -83,7 +83,7 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         logger.setup(Logger.LogLevel.Stop, false);
 
         await this.configurationDone.wait(1000);
-        this.runtime.start(args['porter-file'], !!args.stopOnEntry);
+        this.runtime.start(args['porter-file'], !!args.stopOnEntry, args.porterInputs);
 
         this.sendResponse(response);
     }

--- a/src/debugger/install-session.ts
+++ b/src/debugger/install-session.ts
@@ -60,8 +60,8 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
 
         response.body.supportsStepBack = false;
         response.body.supportsDataBreakpoints = false;
-        response.body.supportsCompletionsRequest = false;
-        // response.body.completionTriggerCharacters = [ ".", "[" ];
+        response.body.supportsCompletionsRequest = true;
+        response.body.completionTriggerCharacters = [ "." ];
 
         // TODO: should this be a thing?
         response.body.supportsCancelRequest = true;
@@ -153,6 +153,26 @@ export class PorterInstallDebugSession extends LoggingDebugSession {
         } else {
             response.success = false;
             response.message = `${args.expression} not defined`;
+        }
+        this.sendResponse(response);
+    }
+
+	protected completionsRequest(response: DebugProtocol.CompletionsResponse, args: DebugProtocol.CompletionsArguments): void {
+        if (args.text === 'bundle.') {
+            response.body = {
+                targets: [
+                    { label: 'parameters' },
+                    { label: 'outputs' },
+                ]
+            };
+        } else if (args.text === 'bundle.parameters.') {
+            response.body = {
+                targets: this.runtime.getParameters().map((v) => ({ label: v.name }))
+            };
+        } else if (args.text === 'bundle.outputs.') {
+            response.body = {
+                targets: [ { label: 'NOT_DONE_YET' } ]  // TODO: do it
+            };
         }
         this.sendResponse(response);
     }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 
 export class PorterInstallRuntime extends EventEmitter {
     private sourceFilePath = '';
+    private porterInputs = '';
 
     public get sourceFile() {
         return this.sourceFilePath;
@@ -15,37 +16,28 @@ export class PorterInstallRuntime extends EventEmitter {
         super();
     }
 
-    public start(porterFilePath: string, stopOnEntry: boolean) {
+    public start(porterFilePath: string, stopOnEntry: boolean, porterInputs: string) {
 
         this.loadSource(porterFilePath);
         this.currentLine = -1;
 
+        this.porterInputs = porterInputs;
+
         if (stopOnEntry) {
-            // we step once
             this.step(false, 'stopOnEntry');
         } else {
-            // we just start to run until we hit a breakpoint or an exception
             this.continue();
         }
     }
 
-    /**
-     * Continue execution to the end/beginning.
-     */
     public continue(reverse = false) {
         this.run(reverse, undefined);
     }
 
-    /**
-     * Step to the next/previous non empty line.
-     */
     public step(reverse = false, event = 'stopOnStep') {
         this.run(reverse, event);
     }
 
-    /**
-     * Returns a fake 'stacktrace'
-     */
     public stack(startFrame: number, endFrame: number): any {
         const frame = {
             index: startFrame,
@@ -63,67 +55,6 @@ export class PorterInstallRuntime extends EventEmitter {
         return [];
     }
 
-    // /*
-    //  * Set breakpoint in file with given line.
-    //  */
-    // public setBreakPoint(path: string, line: number) : MockBreakpoint {
-
-    //     const bp = <MockBreakpoint> { verified: false, line, id: this._breakpointId++ };
-    //     let bps = this._breakPoints.get(path);
-    //     if (!bps) {
-    //         bps = new Array<MockBreakpoint>();
-    //         this._breakPoints.set(path, bps);
-    //     }
-    //     bps.push(bp);
-
-    //     this.verifyBreakpoints(path);
-
-    //     return bp;
-    // }
-
-    // /*
-    //  * Clear breakpoint in file with given line.
-    //  */
-    // public clearBreakPoint(path: string, line: number) : MockBreakpoint | undefined {
-    //     let bps = this._breakPoints.get(path);
-    //     if (bps) {
-    //         const index = bps.findIndex(bp => bp.line === line);
-    //         if (index >= 0) {
-    //             const bp = bps[index];
-    //             bps.splice(index, 1);
-    //             return bp;
-    //         }
-    //     }
-    //     return undefined;
-    // }
-
-    // /*
-    //  * Clear all breakpoints for file.
-    //  */
-    // public clearBreakpoints(path: string): void {
-    //     this._breakPoints.delete(path);
-    // }
-
-    // /*
-    //  * Set data breakpoint.
-    //  */
-    // public setDataBreakpoint(address: string): boolean {
-    //     if (address) {
-    //         this._breakAddresses.add(address);
-    //         return true;
-    //     }
-    //     return false;
-    // }
-
-    // /*
-    //  * Clear all data breakpoints.
-    //  */
-    // public clearAllDataBreakpoints(): void {
-    //     this._breakAddresses.clear();
-    // }
-
-    // private methods
-
     private loadSource(file: string) {
         if (this.sourceFilePath !== file) {
             this.sourceFilePath = file;
@@ -131,16 +62,12 @@ export class PorterInstallRuntime extends EventEmitter {
         }
     }
 
-    /**
-     * Run through the file.
-     * If stepEvent is specified only run a single step and emit the stepEvent.
-     */
     private run(reverse = false, stepEvent?: string) {
         if (reverse) {
             for (let ln = this.currentLine-1; ln >= 0; ln--) {
                 if (this.fireEventsForLine(ln, stepEvent)) {
                     this.currentLine = ln;
-                    return undefined;  // TODO: what should go here?  In template it was just 'return;'
+                    return undefined;
                 }
             }
             // no more lines: stop at first line
@@ -156,91 +83,21 @@ export class PorterInstallRuntime extends EventEmitter {
             // no more lines: run to end
             this.sendEvent('end');
         }
-        return undefined;  // TODO: okay?  In template just fell out the bottom
+        return undefined;
     }
 
-    // private verifyBreakpoints(path: string) : void {
-    //     let bps = this._breakPoints.get(path);
-    //     if (bps) {
-    //         this.loadSource(path);
-    //         bps.forEach(bp => {
-    //             if (!bp.verified && bp.line < this.sourceLines.length) {
-    //                 const srcLine = this.sourceLines[bp.line].trim();
-
-    //                 // if a line is empty or starts with '+' we don't allow to set a breakpoint but move the breakpoint down
-    //                 if (srcLine.length === 0 || srcLine.indexOf('+') === 0) {
-    //                     bp.line++;
-    //                 }
-    //                 // if a line starts with '-' we don't allow to set a breakpoint but move the breakpoint up
-    //                 if (srcLine.indexOf('-') === 0) {
-    //                     bp.line--;
-    //                 }
-    //                 // don't set 'verified' to true if the line contains the word 'lazy'
-    //                 // in this case the breakpoint will be verified 'lazy' after hitting it once.
-    //                 if (srcLine.indexOf('lazy') < 0) {
-    //                     bp.verified = true;
-    //                     this.sendEvent('breakpointValidated', bp);
-    //                 }
-    //             }
-    //         });
-    //     }
-    // }
-
-    /**
-     * Fire events if line has a breakpoint or the word 'exception' is found.
-     * Returns true is execution needs to stop.
-     */
     private fireEventsForLine(ln: number, stepEvent?: string): boolean {
 
         const line = this.sourceLines[ln].trim();
 
-        // if 'log(...)' found in source -> send argument to debug console
-        // const matches = /log\((.*)\)/.exec(line);
-        // if (matches && matches.length === 2) {
-        //     this.sendEvent('output', matches[1], this.sourceFilePath, ln, matches.index);
-        // }
-
-        // // if a word in a line matches a data breakpoint, fire a 'dataBreakpoint' event
-        // const words = line.split(" ");
-        // for (let word of words) {
-        //     if (this._breakAddresses.has(word)) {
-        //         this.sendEvent('stopOnDataBreakpoint');
-        //         return true;
-        //     }
-        // }
-
-        // // if word 'exception' found in source -> throw exception
-        // if (line.indexOf('exception') >= 0) {
-        //     this.sendEvent('stopOnException');
-        //     return true;
-        // }
-
-        // // is there a breakpoint?
-        // const breakpoints = this._breakPoints.get(this.sourceFilePath);
-        // if (breakpoints) {
-        //     const bps = breakpoints.filter(bp => bp.line === ln);
-        //     if (bps.length > 0) {
-
-        //         // send 'stopped' event
-        //         this.sendEvent('stopOnBreakpoint');
-
-        //         // the following shows the use of 'breakpoint' events to update properties of a breakpoint in the UI
-        //         // if breakpoint is not yet verified, verify it now and send a 'breakpoint' update event
-        //         if (!bps[0].verified) {
-        //             bps[0].verified = true;
-        //             this.sendEvent('breakpointValidated', bps[0]);
-        //         }
-        //         return true;
-        //     }
-        // }
-
-        // non-empty line
-        if (stepEvent && line.length > 0) {
+        // for exploration purposes, stop on each line that contains the 'porterInputs' value
+        // THIS IS NOT REAL
+        if (stepEvent && line.length > 0 && line.indexOf(this.porterInputs) > 0) {
             this.sendEvent(stepEvent);
             return true;
         }
 
-        // nothing interesting found -> continue
+        // skip uninteresting lines
         return false;
     }
 

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -97,7 +97,7 @@ export class PorterInstallRuntime extends EventEmitter {
     private fireEventsForLine(ln: number, stepEvent?: string): boolean {
 
         if (stepEvent && this.isFirstLineOfInstallStep(ln)) {
-            // TODO: this.sendEvent('output', whatever_porter_output_from_this_step, this.sourceFile, ln, 0);
+            // TODO: this.sendEvent('output', whatever_porter_output_from_the_previous_step, this.sourceFile, ln, 0);
             this.sendEvent(stepEvent);
             return true;
         }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { EventEmitter } from "events";
 
 import * as porter from '../porter/porter';
-import { InstallInputs, VariableInfo, LazyVariableInfo } from './session-parameters';
+import { InstallInputs, VariableInfo, LazyVariableInfo, EVENT_STOP_ON_ENTRY, EVENT_STOP_ON_STEP, EVENT_END } from './session-protocol';
 import { shell } from '../utils/shell';
 import { Errorable } from '../utils/errorable';
 import { CredentialSource, isValue, isEnv, isCommand, isPath } from '../porter/porter.objectmodel';
@@ -31,7 +31,7 @@ export class PorterInstallRuntime extends EventEmitter {
         this.installInputs = installInputs;
 
         if (stopOnEntry) {
-            this.step('stopOnEntry');
+            this.step(EVENT_STOP_ON_ENTRY);
         } else {
             this.continue();
         }
@@ -41,7 +41,7 @@ export class PorterInstallRuntime extends EventEmitter {
         this.run(undefined);
     }
 
-    public step(event = 'stopOnStep') {
+    public step(event = EVENT_STOP_ON_STEP) {
         this.run(event);
     }
 
@@ -134,14 +134,14 @@ export class PorterInstallRuntime extends EventEmitter {
             }
         }
         // no more lines: run to end
-        this.sendEvent('end');
+        this.sendEvent(EVENT_END);
         return undefined;
     }
 
     private fireEventsForLine(ln: number, stepEvent?: string): boolean {
 
         if (stepEvent && this.isFirstLineOfInstallStep(ln)) {
-            // TODO: this.sendEvent('output', whatever_porter_output_from_the_previous_step, this.sourceFile, ln, 0);
+            // TODO: this.sendEvent(EVENT_OUTPUT, whatever_porter_output_from_the_previous_step, this.sourceFile, ln, 0);
             this.sendEvent(stepEvent);
             return true;
         }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -1,0 +1,253 @@
+import { readFileSync } from 'fs';
+import { EventEmitter } from "events";
+
+export class PorterInstallRuntime extends EventEmitter {
+    private sourceFilePath = '';
+
+    public get sourceFile() {
+        return this.sourceFilePath;
+    }
+
+    private sourceLines: string[] = [];
+    private currentLine = 0;
+
+    constructor() {
+        super();
+    }
+
+    public start(porterFilePath: string, stopOnEntry: boolean) {
+
+        this.loadSource(porterFilePath);
+        this.currentLine = -1;
+
+        if (stopOnEntry) {
+            // we step once
+            this.step(false, 'stopOnEntry');
+        } else {
+            // we just start to run until we hit a breakpoint or an exception
+            this.continue();
+        }
+    }
+
+    /**
+     * Continue execution to the end/beginning.
+     */
+    public continue(reverse = false) {
+        this.run(reverse, undefined);
+    }
+
+    /**
+     * Step to the next/previous non empty line.
+     */
+    public step(reverse = false, event = 'stopOnStep') {
+        this.run(reverse, event);
+    }
+
+    /**
+     * Returns a fake 'stacktrace'
+     */
+    public stack(startFrame: number, endFrame: number): any {
+        const frame = {
+            index: startFrame,
+            name: "Porter",
+            file: this.sourceFilePath,
+            line: this.currentLine
+        };
+        return {
+            frames: [frame],
+            count: 1
+        };
+    }
+
+    public getBreakpoints(path: string, line: number): number[] {
+        return [];
+    }
+
+    // /*
+    //  * Set breakpoint in file with given line.
+    //  */
+    // public setBreakPoint(path: string, line: number) : MockBreakpoint {
+
+    //     const bp = <MockBreakpoint> { verified: false, line, id: this._breakpointId++ };
+    //     let bps = this._breakPoints.get(path);
+    //     if (!bps) {
+    //         bps = new Array<MockBreakpoint>();
+    //         this._breakPoints.set(path, bps);
+    //     }
+    //     bps.push(bp);
+
+    //     this.verifyBreakpoints(path);
+
+    //     return bp;
+    // }
+
+    // /*
+    //  * Clear breakpoint in file with given line.
+    //  */
+    // public clearBreakPoint(path: string, line: number) : MockBreakpoint | undefined {
+    //     let bps = this._breakPoints.get(path);
+    //     if (bps) {
+    //         const index = bps.findIndex(bp => bp.line === line);
+    //         if (index >= 0) {
+    //             const bp = bps[index];
+    //             bps.splice(index, 1);
+    //             return bp;
+    //         }
+    //     }
+    //     return undefined;
+    // }
+
+    // /*
+    //  * Clear all breakpoints for file.
+    //  */
+    // public clearBreakpoints(path: string): void {
+    //     this._breakPoints.delete(path);
+    // }
+
+    // /*
+    //  * Set data breakpoint.
+    //  */
+    // public setDataBreakpoint(address: string): boolean {
+    //     if (address) {
+    //         this._breakAddresses.add(address);
+    //         return true;
+    //     }
+    //     return false;
+    // }
+
+    // /*
+    //  * Clear all data breakpoints.
+    //  */
+    // public clearAllDataBreakpoints(): void {
+    //     this._breakAddresses.clear();
+    // }
+
+    // private methods
+
+    private loadSource(file: string) {
+        if (this.sourceFilePath !== file) {
+            this.sourceFilePath = file;
+            this.sourceLines = readFileSync(this.sourceFilePath).toString().split('\n');
+        }
+    }
+
+    /**
+     * Run through the file.
+     * If stepEvent is specified only run a single step and emit the stepEvent.
+     */
+    private run(reverse = false, stepEvent?: string) {
+        if (reverse) {
+            for (let ln = this.currentLine-1; ln >= 0; ln--) {
+                if (this.fireEventsForLine(ln, stepEvent)) {
+                    this.currentLine = ln;
+                    return undefined;  // TODO: what should go here?  In template it was just 'return;'
+                }
+            }
+            // no more lines: stop at first line
+            this.currentLine = 0;
+            this.sendEvent('stopOnEntry');
+        } else {
+            for (let ln = this.currentLine+1; ln < this.sourceLines.length; ln++) {
+                if (this.fireEventsForLine(ln, stepEvent)) {
+                    this.currentLine = ln;
+                    return true;
+                }
+            }
+            // no more lines: run to end
+            this.sendEvent('end');
+        }
+        return undefined;  // TODO: okay?  In template just fell out the bottom
+    }
+
+    // private verifyBreakpoints(path: string) : void {
+    //     let bps = this._breakPoints.get(path);
+    //     if (bps) {
+    //         this.loadSource(path);
+    //         bps.forEach(bp => {
+    //             if (!bp.verified && bp.line < this.sourceLines.length) {
+    //                 const srcLine = this.sourceLines[bp.line].trim();
+
+    //                 // if a line is empty or starts with '+' we don't allow to set a breakpoint but move the breakpoint down
+    //                 if (srcLine.length === 0 || srcLine.indexOf('+') === 0) {
+    //                     bp.line++;
+    //                 }
+    //                 // if a line starts with '-' we don't allow to set a breakpoint but move the breakpoint up
+    //                 if (srcLine.indexOf('-') === 0) {
+    //                     bp.line--;
+    //                 }
+    //                 // don't set 'verified' to true if the line contains the word 'lazy'
+    //                 // in this case the breakpoint will be verified 'lazy' after hitting it once.
+    //                 if (srcLine.indexOf('lazy') < 0) {
+    //                     bp.verified = true;
+    //                     this.sendEvent('breakpointValidated', bp);
+    //                 }
+    //             }
+    //         });
+    //     }
+    // }
+
+    /**
+     * Fire events if line has a breakpoint or the word 'exception' is found.
+     * Returns true is execution needs to stop.
+     */
+    private fireEventsForLine(ln: number, stepEvent?: string): boolean {
+
+        const line = this.sourceLines[ln].trim();
+
+        // if 'log(...)' found in source -> send argument to debug console
+        // const matches = /log\((.*)\)/.exec(line);
+        // if (matches && matches.length === 2) {
+        //     this.sendEvent('output', matches[1], this.sourceFilePath, ln, matches.index);
+        // }
+
+        // // if a word in a line matches a data breakpoint, fire a 'dataBreakpoint' event
+        // const words = line.split(" ");
+        // for (let word of words) {
+        //     if (this._breakAddresses.has(word)) {
+        //         this.sendEvent('stopOnDataBreakpoint');
+        //         return true;
+        //     }
+        // }
+
+        // // if word 'exception' found in source -> throw exception
+        // if (line.indexOf('exception') >= 0) {
+        //     this.sendEvent('stopOnException');
+        //     return true;
+        // }
+
+        // // is there a breakpoint?
+        // const breakpoints = this._breakPoints.get(this.sourceFilePath);
+        // if (breakpoints) {
+        //     const bps = breakpoints.filter(bp => bp.line === ln);
+        //     if (bps.length > 0) {
+
+        //         // send 'stopped' event
+        //         this.sendEvent('stopOnBreakpoint');
+
+        //         // the following shows the use of 'breakpoint' events to update properties of a breakpoint in the UI
+        //         // if breakpoint is not yet verified, verify it now and send a 'breakpoint' update event
+        //         if (!bps[0].verified) {
+        //             bps[0].verified = true;
+        //             this.sendEvent('breakpointValidated', bps[0]);
+        //         }
+        //         return true;
+        //     }
+        // }
+
+        // non-empty line
+        if (stepEvent && line.length > 0) {
+            this.sendEvent(stepEvent);
+            return true;
+        }
+
+        // nothing interesting found -> continue
+        return false;
+    }
+
+    private sendEvent(event: string, ... args: any[]) {
+        setImmediate((_) => {
+            this.emit(event, ...args);
+        });
+    }
+
+}

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -2,21 +2,11 @@ import { readFileSync } from 'fs';
 import { EventEmitter } from "events";
 
 import * as porter from '../porter/porter';
-import { InstallInputs } from './session-parameters';
+import { InstallInputs, VariableInfo, LazyVariableInfo } from './session-parameters';
 import { shell } from '../utils/shell';
 import { Errorable } from '../utils/errorable';
 import { CredentialSource, isValue, isEnv, isCommand, isPath } from '../porter/porter.objectmodel';
 import { fs } from '../utils/fs';
-
-export interface VariableInfo {
-    readonly name: string;
-    readonly value: string;
-}
-
-export interface LazyVariableInfo {
-    readonly name: string;
-    readonly value: () => Promise<Errorable<string>>;
-}
 
 export class PorterInstallRuntime extends EventEmitter {
     private sourceFilePath = '';

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -181,30 +181,15 @@ export class PorterInstallRuntime extends EventEmitter {
     }
 
     private isFirstLineOfInstallStep(ln: number): boolean {
-        // TODO: use a real YAML parser
-        const currentLine = this.sourceLines[ln];
-        if (!currentLine.trim().startsWith('-')) {
+        if (!this.sourceYAML) {
             return false;
         }
-        const currentIndent = indentSize(currentLine);
-        for (let prevLn = ln - 1; prevLn >= 0; --prevLn) {
-            const prevText = this.sourceLines[prevLn];
-            if (prevText.trim().startsWith(`#`)) {
-                continue;
-            }
-            const indent = indentSize(prevText);
-            if (indent < currentIndent) {
-                return prevText.startsWith('install:');
-            }
-        }
-        return false;
-    }
-}
 
-function indentSize(s: string): number {
-    // TODO: I know but just leave it for now okay
-    if (s.startsWith(' ')) {
-        return 1 + indentSize(s.substring(1));
+        const action = this.sourceYAML.actions.find((a) => a.name === 'install');
+        if (!action) {
+            return false;
+        }
+
+        return action.steps.some((s) => s.startLine === ln);
     }
-    return 0;
 }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -25,18 +25,18 @@ export class PorterInstallRuntime extends EventEmitter {
         this.installInputs = installInputs;
 
         if (stopOnEntry) {
-            this.step(false, 'stopOnEntry');
+            this.step('stopOnEntry');
         } else {
             this.continue();
         }
     }
 
-    public continue(reverse = false) {
-        this.run(reverse, undefined);
+    public continue() {
+        this.run(undefined);
     }
 
-    public step(reverse = false, event = 'stopOnStep') {
-        this.run(reverse, event);
+    public step(event = 'stopOnStep') {
+        this.run(event);
     }
 
     public stack(startFrame: number, endFrame: number): any {
@@ -70,27 +70,15 @@ export class PorterInstallRuntime extends EventEmitter {
         }
     }
 
-    private run(reverse = false, stepEvent?: string) {
-        if (reverse) {
-            for (let ln = this.currentLine-1; ln >= 0; ln--) {
-                if (this.fireEventsForLine(ln, stepEvent)) {
-                    this.currentLine = ln;
-                    return undefined;
-                }
+    private run(stepEvent?: string) {
+        for (let ln = this.currentLine+1; ln < this.sourceLines.length; ln++) {
+            if (this.fireEventsForLine(ln, stepEvent)) {
+                this.currentLine = ln;
+                return true;
             }
-            // no more lines: stop at first line
-            this.currentLine = 0;
-            this.sendEvent('stopOnEntry');
-        } else {
-            for (let ln = this.currentLine+1; ln < this.sourceLines.length; ln++) {
-                if (this.fireEventsForLine(ln, stepEvent)) {
-                    this.currentLine = ln;
-                    return true;
-                }
-            }
-            // no more lines: run to end
-            this.sendEvent('end');
         }
+        // no more lines: run to end
+        this.sendEvent('end');
         return undefined;
     }
 

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -85,6 +85,20 @@ export class PorterInstallRuntime extends EventEmitter {
         return [];
     }
 
+    public async getOutputs(): Promise<LazyVariableInfo[]> {
+        // if (this.credentials !== undefined)  {
+        //     return this.credentials;
+        // }
+        // if (this.installInputs && this.installInputs.credentialSet) {
+        //     const credentials = await porter.getCredentials(shell, this.installInputs.credentialSet);
+        //     if (credentials.succeeded) {
+        //         this.credentials = credentials.result.credentials.map((c) => ({ name: c.name, value: () => this.evaluateCredential(c.source) }));
+        //         return this.credentials;
+        //     }
+        // }
+        return [ { name: 'NOT_DONE_YET', value: async () => ({ succeeded: true, result: "I told you, it's not done yet!" }) } ];
+    }
+
     private async evaluateCredential(source: CredentialSource): Promise<Errorable<string>> {
         if (isValue(source)) {
             return { succeeded: true, result: source.value };

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'fs';
 import { EventEmitter } from "events";
+import { InstallInputs } from './session-parameters';
 
 export class PorterInstallRuntime extends EventEmitter {
     private sourceFilePath = '';
-    private porterInputs = '';
+    private installInputs: InstallInputs | undefined = undefined;
 
     public get sourceFile() {
         return this.sourceFilePath;
@@ -16,12 +17,12 @@ export class PorterInstallRuntime extends EventEmitter {
         super();
     }
 
-    public start(porterFilePath: string, stopOnEntry: boolean, porterInputs: string) {
+    public start(porterFilePath: string, stopOnEntry: boolean, installInputs: InstallInputs) {
 
         this.loadSource(porterFilePath);
         this.currentLine = -1;
 
-        this.porterInputs = porterInputs;
+        this.installInputs = installInputs;
 
         if (stopOnEntry) {
             this.step(false, 'stopOnEntry');
@@ -90,9 +91,7 @@ export class PorterInstallRuntime extends EventEmitter {
 
         const line = this.sourceLines[ln].trim();
 
-        // for exploration purposes, stop on each line that contains the 'porterInputs' value
-        // THIS IS NOT REAL
-        if (stepEvent && line.length > 0 && line.indexOf(this.porterInputs) > 0) {
+        if (stepEvent && line.length > 0 && /* TODO: NOT REALLY NOT REALLY AT ALL */ this.testytestytesttest(line)) {
             this.sendEvent(stepEvent);
             return true;
         }
@@ -107,4 +106,14 @@ export class PorterInstallRuntime extends EventEmitter {
         });
     }
 
+    // TODO: this is for proof of concept and not a real thing
+    testytestytesttest(line: string) {
+        const parameters = this.installInputs!.parameters || {};
+        for (const pval of Object.values(parameters)) {
+            if (line.indexOf(pval) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -55,7 +55,7 @@ export class PorterInstallRuntime extends EventEmitter {
         this.run(event);
     }
 
-    public stack(startFrame: number, endFrame: number): any {
+    public stack(startFrame: number, endFrame: number) {
         const frame = {
             index: startFrame,
             name: "Porter",

--- a/src/debugger/session-parameters.ts
+++ b/src/debugger/session-parameters.ts
@@ -1,0 +1,4 @@
+export interface InstallInputs {
+    readonly parameters?: { [key: string]: string };
+    readonly credentialSet?: string;
+}

--- a/src/debugger/session-parameters.ts
+++ b/src/debugger/session-parameters.ts
@@ -1,4 +1,16 @@
+import { Errorable } from "../utils/errorable";
+
 export interface InstallInputs {
     readonly parameters?: { [key: string]: string };
     readonly credentialSet?: string;
+}
+
+export interface VariableInfo {
+    readonly name: string;
+    readonly value: string;
+}
+
+export interface LazyVariableInfo {
+    readonly name: string;
+    readonly value: () => Promise<Errorable<string>>;
 }

--- a/src/debugger/session-protocol.ts
+++ b/src/debugger/session-protocol.ts
@@ -1,5 +1,10 @@
 import { Errorable } from "../utils/errorable";
 
+export const EVENT_STOP_ON_ENTRY = 'stopOnEntry';
+export const EVENT_STOP_ON_STEP = 'stopOnStep';
+export const EVENT_OUTPUT = 'output';
+export const EVENT_END = 'end';
+
 export interface InstallInputs {
     readonly parameters?: { [key: string]: string };
     readonly credentialSet?: string;

--- a/src/debugger/session-protocol.ts
+++ b/src/debugger/session-protocol.ts
@@ -2,6 +2,8 @@ import { Errorable } from "../utils/errorable";
 
 export const EVENT_STOP_ON_ENTRY = 'stopOnEntry';
 export const EVENT_STOP_ON_STEP = 'stopOnStep';
+export const EVENT_STOP_ON_BREAKPOINT = 'stopOnBreakpoint';
+export const EVENT_BREAKPOINT_VALIDATED = 'breakpointValidated';
 export const EVENT_OUTPUT = 'output';
 export const EVENT_END = 'end';
 
@@ -18,4 +20,10 @@ export interface VariableInfo {
 export interface LazyVariableInfo {
     readonly name: string;
     readonly value: () => Promise<Errorable<string>>;
+}
+
+export interface PorterBreakpoint {
+    readonly id: number;
+    line: number;
+    verified: boolean;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,14 +10,22 @@ import { registerYamlSchema, updateYamlSchema } from './yaml/yaml-schema';
 import { promptForCredentials } from './utils/credentials';
 import { suggestName, folderSelection, displayName, manifest } from './utils/bundleselection';
 import { promptForParameters } from './utils/parameters';
+import { PorterInstallConfigurationProvider } from './debugger/configuration-provider';
+import { PorterInstallDebugAdapterDescriptorFactory } from './debugger/descriptor-factory';
 
 const PORTER_OUTPUT_CHANNEL = vscode.window.createOutputChannel('Porter');
 
 export async function activate(context: vscode.ExtensionContext) {
+    const debugConfigurationProvider = new PorterInstallConfigurationProvider();
+    const debugFactory = new PorterInstallDebugAdapterDescriptorFactory();
+
     const subscriptions = [
         vscode.commands.registerCommand('porter.createProject', createProject),
         vscode.commands.registerCommand('porter.build', build),
         vscode.commands.registerCommand('porter.install', install),
+        vscode.debug.registerDebugConfigurationProvider('porter', debugConfigurationProvider),
+		vscode.debug.registerDebugAdapterDescriptorFactory('porter', debugFactory),
+		debugFactory
     ];
 
     context.subscriptions.push(...subscriptions);

--- a/src/porter/porter.objectmodel.ts
+++ b/src/porter/porter.objectmodel.ts
@@ -2,3 +2,23 @@ export interface CredentialInfo {
     readonly Name: string;
     readonly Modified: string;
 }
+
+export interface CredentialSetContent {
+    readonly name: string;
+    readonly credentials: Credential[];
+}
+
+export interface Credential {
+    readonly name: string;
+    readonly source: CredentialSource;
+}
+
+export interface ValueCredentialSource {
+    readonly value: string;
+}
+
+export interface EnvironmentVariableCredentialSource {
+    readonly env: string;
+}
+
+export type CredentialSource = ValueCredentialSource | EnvironmentVariableCredentialSource;

--- a/src/porter/porter.objectmodel.ts
+++ b/src/porter/porter.objectmodel.ts
@@ -21,4 +21,28 @@ export interface EnvironmentVariableCredentialSource {
     readonly env: string;
 }
 
-export type CredentialSource = ValueCredentialSource | EnvironmentVariableCredentialSource;
+export interface PathCredentialSource {
+    readonly path: string;
+}
+
+export interface ShellCommandCredentialSource {
+    readonly command: string;
+}
+
+export type CredentialSource = ValueCredentialSource | EnvironmentVariableCredentialSource | PathCredentialSource | ShellCommandCredentialSource;
+
+export function isValue(s: CredentialSource): s is ValueCredentialSource {
+    return (s as any).value;
+}
+
+export function isEnv(s: CredentialSource): s is EnvironmentVariableCredentialSource {
+    return (s as any).env;
+}
+
+export function isPath(s: CredentialSource): s is PathCredentialSource {
+    return (s as any).path;
+}
+
+export function isCommand(s: CredentialSource): s is ShellCommandCredentialSource {
+    return (s as any).command;
+}

--- a/src/porter/porter.ts
+++ b/src/porter/porter.ts
@@ -7,7 +7,7 @@ import { Errorable } from '../utils/errorable';
 import * as shell from '../utils/shell';
 import { fs } from '../utils/fs';
 import * as pairs from '../utils/pairs';
-import { CredentialInfo } from './porter.objectmodel';
+import { CredentialInfo, CredentialSetContent } from './porter.objectmodel';
 
 const logChannel = vscode.window.createOutputChannel("Porter");
 
@@ -40,6 +40,13 @@ export async function listCredentialSets(sh: shell.Shell): Promise<Errorable<str
             .map((c) => c.Name);
     }
     return await invokeObj(sh, 'credentials list', '-o json', { }, parse);
+}
+
+export async function getCredentials(sh: shell.Shell, credentialSetName: string): Promise<Errorable<CredentialSetContent>> {
+    function parse(stdout: string): CredentialSetContent {
+        return JSON.parse(stdout);
+    }
+    return await invokeObj(sh, 'credentials show', `${credentialSetName} -o json`, { }, parse);
 }
 
 export async function create(sh: shell.Shell, folder: string): Promise<Errorable<string>> {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,7 @@
+export function flatten<T>(...arrays: ReadonlyArray<T>[]): ReadonlyArray<T> {
+    return Array.of<T>().concat(...arrays);
+}
+
+export function definedOf<T>(...items: (T | undefined)[]): T[] {
+    return items.filter((i) => i !== undefined).map((i) => i!);
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,18 @@
+export function formatHyphenated(date: Date): string {
+    const year = zeroPad(date.getFullYear(), 4);
+    const month = zeroPad(date.getMonth() + 1, 2);
+    const day = zeroPad(date.getDate(), 2);
+    const hour = zeroPad(date.getHours(), 2);
+    const minute = zeroPad(date.getMinutes(), 2);
+    const second = zeroPad(date.getSeconds(), 2);
+    return [year, month, day, hour, minute, second].join('-');
+}
+
+export function zeroPad(n: number, length: number): string {
+    // This isn't optimised because it doesn't have to be
+    let s = n.toString();
+    while (s.length < length) {
+        s = '0' + s;
+    }
+    return s;
+}

--- a/src/utils/pathmap.ts
+++ b/src/utils/pathmap.ts
@@ -1,0 +1,44 @@
+// We need this instead of a normal Map<string, T> because sometimes VS Code likes to
+// mix it up in terms of / and \ even within a single file path.  And also uses inconsistent
+// casing for drive letters and sometimes even file names on Windows.
+export class PathMap<T> {
+    private readonly _impl = new Map<string, T>();
+
+    private normalise(path: string) {
+        return path.replace(/\\/g, '/').toLowerCase();  // TODO: This is rude on Linux, but the casing seems to mess us up on Windows
+    }
+
+    get(path: string) {
+        return this._impl.get(this.normalise(path));
+    }
+
+    set(path: string, value: T) {
+        return this._impl.set(this.normalise(path), value);
+    }
+
+    delete(path: string) {
+        return this._impl.delete(this.normalise(path));
+    }
+}
+
+export class PathMapList<T> {
+    private readonly _impl = new PathMap<T[]>();
+
+    get(path: string) {
+        return this._impl.get(path);
+    }
+
+    append(path: string, value: T) {
+        const existing = this.get(path);
+        if (existing) {
+            existing.push(value);
+        } else {
+            this._impl.set(path, [value]);
+        }
+        return this;
+    }
+
+    delete(path: string) {
+        return this._impl.delete(path);
+    }
+}


### PR DESCRIPTION
This is a work-in-progress learning exercise for building a Porter debugger.  At this stage the stepping is faked - no actual install work is done during any step, as this requires support from the Porter side.  Consequently, we can show only parameters and credentials, not step outputs.  However, it does allow us to get our heads around features such as:

* Hover over expressions to show their values
* Evaluate expressions in the Debug window
* Auto complete expressions in the Debug REPL
* Implementing a stepping UI that halts on each step
* Run to step containing next breakpoint
* Displaying variables in the Variables window
* Setting up a debug configuration to launch a Porter debug session
* Prompting for required info as part of debug session startup

The code is pretty shonky right now, and could do with some serious tidying up.  But I'm putting this out as a PR so people can play with it and get a sense for what an eventual debug experience could look like.