### PR TITLE
Command to move a step up or down

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
         "onCommand:porter.build",
         "onCommand:porter.install",
         "onCommand:porter.insertHelmChart",
+        "onCommand:porter.moveStepUp",
+        "onCommand:porter.moveStepDown",
         "onView:extension.vsKubernetesHelmRepoExplorer",
         "onDebugResolve:porter",
         "onLanguage:yaml"
@@ -47,6 +49,16 @@
                 "command": "porter.insertHelmChart",
                 "title": "Insert Chart into Porter Bundle",
                 "category": "Porter"
+            },
+            {
+                "command": "porter.moveStepUp",
+                "title": "Move Step Up",
+                "category": "Porter"
+            },
+            {
+                "command": "porter.moveStepDown",
+                "title": "Move Step Down",
+                "category": "Porter"
             }
         ],
         "menus": {
@@ -55,6 +67,18 @@
                     "command": "porter.insertHelmChart",
                     "group": "9",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "porter.moveStepUp",
+                    "group": "9@1",
+                    "when": "resourceFilename =~ /porter\\.yaml/i"
+                },
+                {
+                    "command": "porter.moveStepDown",
+                    "group": "9@2",
+                    "when": "resourceFilename =~ /porter\\.yaml/i"
                 }
             ]
         },

--- a/src/commands/movestep.ts
+++ b/src/commands/movestep.ts
@@ -2,14 +2,14 @@ import * as vscode from 'vscode';
 
 import * as ast from '../porter/ast';
 
-const EMPTY_DISPOSABLE = new vscode.Disposable(() => undefined);
-
 abstract class MoveStepDirection {
     abstract allowsMove(action: ast.PorterActionYAML, stepIndex: number): boolean;
     abstract readonly utmost: string;
     abstract readonly name: string;
     abstract moverIndex(stepIndex: number): number;
     abstract moveTargetIndex(stepIndex: number): number;
+    abstract cursorOffsetSizeStepIndex(stepIndex: number): number;
+    abstract yFactor: number;
 
     static readonly UP: MoveStepDirection = {
         allowsMove(_action, stepIndex) {
@@ -18,7 +18,9 @@ abstract class MoveStepDirection {
         utmost: 'top',
         name: 'up',
         moverIndex(stepIndex) { return stepIndex; },
-        moveTargetIndex(stepIndex) { return stepIndex - 1; }
+        moveTargetIndex(stepIndex) { return stepIndex - 1; },
+        cursorOffsetSizeStepIndex(stepIndex) { return stepIndex - 1; },
+        yFactor: -1
     };
 
     static readonly DOWN: MoveStepDirection = {
@@ -28,60 +30,65 @@ abstract class MoveStepDirection {
         utmost: 'bottom',
         name: 'down',
         moverIndex(stepIndex) { return stepIndex + 1; },
-        moveTargetIndex(stepIndex) { return stepIndex; }
+        moveTargetIndex(stepIndex) { return stepIndex; },
+        cursorOffsetSizeStepIndex(stepIndex) { return stepIndex + 1; },
+        yFactor: 1
     };
 }
 
-export function moveStepUp(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): vscode.Disposable {
-    return moveStep(editor, edit, MoveStepDirection.UP);
+export function moveStepUp(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): void {
+    moveStep(editor, edit, MoveStepDirection.UP);
 }
 
-export function moveStepDown(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): vscode.Disposable {
-    return moveStep(editor, edit, MoveStepDirection.DOWN);
+export function moveStepDown(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): void {
+    moveStep(editor, edit, MoveStepDirection.DOWN);
 }
 
-function moveStep(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, direction: MoveStepDirection): vscode.Disposable {
+function moveStep(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, direction: MoveStepDirection): void {
     const document = editor.document;
     if (!document.uri.fsPath.toLowerCase().endsWith('porter.yaml')) {
         vscode.window.showErrorMessage('This command requires an open editor containing the porter.yaml to insert into');
-        return EMPTY_DISPOSABLE;
+        return;
     }
     const manifest = ast.parse(document.getText());
     if (!manifest) {
         vscode.window.showErrorMessage('Unable to parse open porter.yaml file: please fix any errors and try again');
-        return EMPTY_DISPOSABLE;
+        return;
     }
 
-    const cursorLocation = locateCursorInActions(manifest, editor.selection.active.line);
+    const originalCursorPosition = editor.selection.active;
+    const cursorLocation = locateCursorInActions(manifest, originalCursorPosition.line);
     if (!cursorLocation) {
         vscode.window.showErrorMessage('This command requires the cursor to be on the step you want to move');
-        return EMPTY_DISPOSABLE;
+        return;
     }
 
     const [action, stepIndex] = cursorLocation;
 
     if (!direction.allowsMove(action, stepIndex)) {
         vscode.window.showInformationMessage(`This step is already at the ${direction.utmost} and cannot be moved ${direction.name}`);
-        return EMPTY_DISPOSABLE;
+        return;
     }
 
-    // TODO: MOVE IT MOVE IT
     const movingStepIndex = direction.moverIndex(stepIndex);
     const moveTargetIndex = direction.moveTargetIndex(stepIndex);
+    const cursorOffsetSizeStepIndex = direction.cursorOffsetSizeStepIndex(stepIndex);
 
     const movingStep = action.steps[movingStepIndex];
     const moveTargetStep = action.steps[moveTargetIndex];
+    const cursorOffsetSizeStep = action.steps[cursorOffsetSizeStepIndex];
 
     const movingStepRange = new vscode.Range(movingStep.startLine, 0, movingStep.endLine + 1, 0);
     const movingStepText = editor.document.getText(movingStepRange);
     const targetPosition = new vscode.Position(moveTargetStep.startLine, 0);
+    const cursorTranslateLines = (cursorOffsetSizeStep.endLine - cursorOffsetSizeStep.startLine + 1) * direction.yFactor;
+    const newCursorPosition = originalCursorPosition.translate(cursorTranslateLines, 0);
 
     edit.delete(movingStepRange);
     edit.insert(targetPosition, movingStepText);
+    editor.selection = new vscode.Selection(newCursorPosition, newCursorPosition);
 
-    // TODO: position cursor at the location where it originally was within the moved step
-
-    return EMPTY_DISPOSABLE;
+    return;
 }
 
 function locateCursorInActions(manifest: ast.PorterManifestYAML, line: number): [ast.PorterActionYAML, number] | undefined {

--- a/src/commands/movestep.ts
+++ b/src/commands/movestep.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+
+import * as ast from '../porter/ast';
+
+const EMPTY_DISPOSABLE = new vscode.Disposable(() => undefined);
+
+abstract class MoveStepDirection {
+    abstract allowsMove(action: ast.PorterActionYAML, stepIndex: number): boolean;
+    abstract readonly utmost: string;
+    abstract readonly name: string;
+    abstract moverIndex(stepIndex: number): number;
+    abstract moveTargetIndex(stepIndex: number): number;
+
+    static readonly UP: MoveStepDirection = {
+        allowsMove(_action, stepIndex) {
+            return stepIndex > 0;
+        },
+        utmost: 'top',
+        name: 'up',
+        moverIndex(stepIndex) { return stepIndex; },
+        moveTargetIndex(stepIndex) { return stepIndex - 1; }
+    };
+
+    static readonly DOWN: MoveStepDirection = {
+        allowsMove(action, stepIndex) {
+            return stepIndex < action.steps.length - 1;
+        },
+        utmost: 'bottom',
+        name: 'down',
+        moverIndex(stepIndex) { return stepIndex + 1; },
+        moveTargetIndex(stepIndex) { return stepIndex; }
+    };
+}
+
+export function moveStepUp(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): vscode.Disposable {
+    return moveStep(editor, edit, MoveStepDirection.UP);
+}
+
+export function moveStepDown(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]): vscode.Disposable {
+    return moveStep(editor, edit, MoveStepDirection.DOWN);
+}
+
+function moveStep(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, direction: MoveStepDirection): vscode.Disposable {
+    const document = editor.document;
+    if (!document.uri.fsPath.toLowerCase().endsWith('porter.yaml')) {
+        vscode.window.showErrorMessage('This command requires an open editor containing the porter.yaml to insert into');
+        return EMPTY_DISPOSABLE;
+    }
+    const manifest = ast.parse(document.getText());
+    if (!manifest) {
+        vscode.window.showErrorMessage('Unable to parse open porter.yaml file: please fix any errors and try again');
+        return EMPTY_DISPOSABLE;
+    }
+
+    const cursorLocation = locateCursorInActions(manifest, editor.selection.active.line);
+    if (!cursorLocation) {
+        vscode.window.showErrorMessage('This command requires the cursor to be on the step you want to move');
+        return EMPTY_DISPOSABLE;
+    }
+
+    const [action, stepIndex] = cursorLocation;
+
+    if (!direction.allowsMove(action, stepIndex)) {
+        vscode.window.showInformationMessage(`This step is already at the ${direction.utmost} and cannot be moved ${direction.name}`);
+        return EMPTY_DISPOSABLE;
+    }
+
+    // TODO: MOVE IT MOVE IT
+    const movingStepIndex = direction.moverIndex(stepIndex);
+    const moveTargetIndex = direction.moveTargetIndex(stepIndex);
+
+    const movingStep = action.steps[movingStepIndex];
+    const moveTargetStep = action.steps[moveTargetIndex];
+
+    const movingStepRange = new vscode.Range(movingStep.startLine, 0, movingStep.endLine + 1, 0);
+    const movingStepText = editor.document.getText(movingStepRange);
+    const targetPosition = new vscode.Position(moveTargetStep.startLine, 0);
+
+    edit.delete(movingStepRange);
+    edit.insert(targetPosition, movingStepText);
+
+    // TODO: position cursor at the location where it originally was within the moved step
+
+    return EMPTY_DISPOSABLE;
+}
+
+function locateCursorInActions(manifest: ast.PorterManifestYAML, line: number): [ast.PorterActionYAML, number] | undefined {
+    for (const action of manifest.actions) {
+        for (let i = 0; i < action.steps.length; ++i) {
+            const step = action.steps[i];
+            if (step.startLine <= line && line <= step.endLine) {
+                return [action, i];
+            }
+        }
+    }
+    return undefined;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { promptForParameters } from './utils/parameters';
 import { PorterInstallConfigurationProvider } from './debugger/configuration-provider';
 import { PorterInstallDebugAdapterDescriptorFactory } from './debugger/descriptor-factory';
 import { insertHelmChart } from './commands/inserthelmchart';
+import { moveStepUp, moveStepDown } from './commands/movestep';
 
 const PORTER_OUTPUT_CHANNEL = vscode.window.createOutputChannel('Porter');
 
@@ -25,6 +26,8 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('porter.build', build),
         vscode.commands.registerCommand('porter.install', install),
         vscode.commands.registerCommand('porter.insertHelmChart', insertHelmChart),
+        vscode.commands.registerTextEditorCommand('porter.moveStepUp', moveStepUp),
+        vscode.commands.registerTextEditorCommand('porter.moveStepDown', moveStepDown),
         vscode.debug.registerDebugConfigurationProvider('porter', debugConfigurationProvider),
 		vscode.debug.registerDebugAdapterDescriptorFactory('porter', debugFactory),
 		debugFactory


### PR DESCRIPTION
This has one known issue at the moment: when done, the cursor is left after the two steps that got swapped, _not_ returned to its original position.  This can't be fixed within the VS Code text editor command framework: need to decide whether to chuck the text editor command stuff and reimplement it all, or accept this wart.