### PR TITLE
Go to definition

### DIFF
--- a/src/commands/inserthelmchart.ts
+++ b/src/commands/inserthelmchart.ts
@@ -122,7 +122,7 @@ function syntheticAction(editor: vscode.TextEditor, actionName: string): ast.Por
     // if the action has no steps then it may not be parsed as an action
     const unparsedActionLine = findLine(editor.document, `${actionName}:`);
     if (unparsedActionLine !== undefined) {
-        return { name: actionName, startLine: unparsedActionLine, steps: [] };
+        return { name: actionName, startLine: unparsedActionLine, endLine: unparsedActionLine, steps: [] };
     }
     return undefined;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,10 +15,12 @@ import { PorterInstallDebugAdapterDescriptorFactory } from './debugger/descripto
 import { insertHelmChart } from './commands/inserthelmchart';
 import { moveStepUp, moveStepDown } from './commands/movestep';
 import { parameteriseSelection } from './commands/parameterise';
+import * as definitionprovider from './navigation/definitionprovider';
 
 const PORTER_OUTPUT_CHANNEL = vscode.window.createOutputChannel('Porter');
 
 export async function activate(context: vscode.ExtensionContext) {
+    const definitionProvider = definitionprovider.create();
     const debugConfigurationProvider = new PorterInstallConfigurationProvider();
     const debugFactory = new PorterInstallDebugAdapterDescriptorFactory();
 
@@ -30,6 +32,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerTextEditorCommand('porter.moveStepUp', moveStepUp),
         vscode.commands.registerTextEditorCommand('porter.moveStepDown', moveStepDown),
         vscode.commands.registerCommand('porter.parameterise', parameteriseSelection),
+        vscode.languages.registerDefinitionProvider({ language: 'yaml', pattern: '**/porter.yaml' }, definitionProvider),
         vscode.debug.registerDebugConfigurationProvider('porter', debugConfigurationProvider),
 		vscode.debug.registerDebugAdapterDescriptorFactory('porter', debugFactory),
 		debugFactory

--- a/src/navigation/definitionprovider.ts
+++ b/src/navigation/definitionprovider.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+import * as ast from '../porter/ast';
+
+export function create(): vscode.DefinitionProvider {
+    return new PorterDefinitionProvider();
+}
+
+class PorterDefinitionProvider implements vscode.DefinitionProvider {
+    provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Location | vscode.Location[] | vscode.LocationLink[]> {
+        // Plan:
+        // * Look around position for the nearest pair of matching {{ }} braces
+        // * If the contents of the braces, trimmed, is *only* 'bundle.<pattern-tba>', we have a candidate reference
+        // * Parse the pattern:
+        //    * If parameter, locate it in the parameters section
+        //    * If credential, locate it in the credentials section
+        //    * If output, locate the step which defines it, then locate the output in the outputs section
+        //  * If not found, return undefined; otherwise return the location
+
+        const line = document.lineAt(position.line);  // Assume references do not break across lines because COME ON PEOPLE
+        // const before = line.text.substring(0, position.character);
+        // const after = line.text.substring(position.character);
+        // TODO: should it work if you are on the braces themselves?  If so need to smart this up
+        const openingBraceIndex = line.text.lastIndexOf('{{', position.character);
+        const closingBraceIndex = line.text.indexOf('}}', position.character);
+
+        if (openingBraceIndex < 0 || closingBraceIndex < 0) {
+            return undefined;
+        }
+
+        const fullSourceText = line.text.substring(openingBraceIndex + 2, closingBraceIndex);
+        const sourceText = fullSourceText.trim();
+
+        const reference = parseReference(sourceText);
+        if (!reference) {
+            return undefined;
+        }
+
+        const manifest = ast.parse(document.getText());
+        if (!manifest) {
+            return undefined;
+        }
+
+        const location = locationIn(manifest, reference, position);
+        if (!location) {
+            return undefined;
+        }
+
+        return new vscode.Location(document.uri, location);
+    }
+}
+
+interface Reference {
+    readonly kind: 'parameter' | 'credential' | 'output';
+    readonly name: string;
+}
+
+function parseReference(text: string): Reference | undefined {
+    const bits = text.trim().split('.');
+    if (bits.length !== 3) {
+        return undefined;
+    }
+    if (bits[0] !== 'bundle') {
+        return undefined;
+    }
+    const kind = asReferenceKind(bits[1]);
+    if (!kind) {
+        return undefined;
+    }
+    const name = bits[2];
+    return { kind, name };
+}
+
+function asReferenceKind(text: string): 'parameter' | 'credential' | 'output' | undefined {
+    switch (text) {
+        case 'parameters': return 'parameter';
+        case 'credentials': return 'credential';
+        case 'outputs': return 'output';
+        default: return undefined;
+    }
+}
+
+function locationIn(manifest: ast.PorterManifestYAML, reference: Reference, referencePosition: vscode.Position): vscode.Range | undefined {
+    if (reference.kind === 'output') {
+        const step = stepContaining(manifest, referencePosition);
+        if (!step) {
+            return undefined;
+        }
+        const definition = step.outputs.find((s) => s.name === reference.name);
+        if (!definition) {
+            return undefined;
+        }
+        return new vscode.Range();
+    }
+
+    const definitions = reference.kind === 'parameter' ? manifest.parameters : manifest.credentials;
+    if (!definitions) {
+        return undefined;
+    }
+    return find_the_name_in_the_section;
+}
+
+function stepContaining(manifest: ast.PorterManifestYAML, position: vscode.Position): ast.PorterStepYAML | undefined {
+
+}

--- a/src/porter/ast.ts
+++ b/src/porter/ast.ts
@@ -1,30 +1,36 @@
 import * as yaml from 'yaml-ast-parser';
 import { YAMLSequence, YAMLNode } from 'yaml-ast-parser';
+import '../utils/array';
 import { definedOf } from '../utils/array';
+import { Range, Position } from 'vscode';
 
 export interface PorterManifestYAML {
-    readonly parameters?: PorterParametersYAML;
+    readonly parameters: PorterDefinitionsYAML | undefined;
+    readonly credentials: PorterDefinitionsYAML | undefined;
     readonly actions: ReadonlyArray<PorterActionYAML>;
 }
 
-export interface PorterParametersYAML {
+export interface PorterDefinitionsYAML {
     readonly startLine: number;
+    readonly entries: ReadonlyArray<PorterDefinitionYAML>;
+}
+
+export interface PorterDefinitionYAML {
+    readonly name: string;
+    readonly nameRange: Range;
 }
 
 export interface PorterActionYAML {
     readonly name: string;
     readonly startLine: number;
+    readonly endLine: number;
     readonly steps: ReadonlyArray<PorterStepYAML>;
 }
 
 export interface PorterStepYAML {
     readonly startLine: number;
     readonly endLine: number;
-    readonly outputs: ReadonlyArray<PorterOutputYAML>;
-}
-
-export interface PorterOutputYAML {
-    readonly name: string;
+    readonly outputs: ReadonlyArray<PorterDefinitionYAML>;
 }
 
 const nonStepArrays = ['mixins', 'parameters', 'credentials'];
@@ -52,21 +58,35 @@ class PorterManifestASTParser {
 
         const mappings = (ast as yaml.YamlMap).mappings;
         const parametersMapping = mappings.find((m) => m.key && m.key.value === 'parameters');
+        const credentialsMapping = mappings.find((m) => m.key && m.key.value === 'credentials');
         const actionMappings = mappings.filter((m) => m.key && m.value && m.value.kind === yaml.Kind.SEQ && nonStepArrays.indexOf(m.key.value) < 0);  // TODO: better heuristics?
 
         return {
-            parameters: this.asParametersAST(parametersMapping),
+            parameters: this.asDefinitionsAST(parametersMapping),
+            credentials: this.asDefinitionsAST(credentialsMapping),
             actions: actionMappings.map((m) => this.asActionAST(m))
         };
     }
 
-    private asParametersAST(m: yaml.YAMLMapping | undefined): PorterParametersYAML | undefined {
+    private asDefinitionsAST(m: yaml.YAMLMapping | undefined): PorterDefinitionsYAML | undefined {
         if (!m) {
             return undefined;
         }
         return {
-            startLine: this.lineOf(m.startPosition)
+            startLine: this.lineOf(m.startPosition),
+            entries: this.asDefinitionASTs(m.value)
         };
+    }
+
+    private asDefinitionASTs(value: yaml.YAMLNode): readonly PorterDefinitionYAML[] {
+        if (value.kind !== yaml.Kind.SEQ) {
+            return [];
+        }
+        const node = value as yaml.YAMLSequence;
+        const definitionNodes = node.items;
+        const definitionCandidates = definitionNodes.filter((n) => n.kind === yaml.Kind.MAP)
+                                                    .map((n) => n as yaml.YamlMap);
+        return definitionCandidates.choose((m) => this.asDefinitionAST(m));
     }
 
     private asActionAST(m: yaml.YAMLMapping): PorterActionYAML {
@@ -78,6 +98,7 @@ class PorterManifestASTParser {
         return {
             name: actionName,
             startLine: lineSpan.startLine,
+            endLine: lineSpan.endLine,
             steps: definedOf(...steppaz)
         };
     }
@@ -105,17 +126,17 @@ class PorterManifestASTParser {
         }
         const outputEntries = (outputSection.value as YAMLSequence).items.filter((o) => o.kind === yaml.Kind.MAP).map((o) => o as yaml.YamlMap);
         return {
-            outputs: definedOf(...outputEntries.map((o) => this.asOutputAST(o))),
+            outputs: definedOf(...outputEntries.map((o) => this.asDefinitionAST(o))),
             ...stepLineSpan
         };
     }
 
-    private asOutputAST(o: yaml.YamlMap): PorterOutputYAML | undefined {
+    private asDefinitionAST(o: yaml.YamlMap): PorterDefinitionYAML | undefined {
         const nameMapping = o.mappings.find((m) => m.key.value === 'name');
         if (!nameMapping) {
             return undefined;
         }
-        return { name: nameMapping.value.value };
+        return { name: nameMapping.value.value, nameRange: this.rangeOf(nameMapping) };
     }
 
     private lineOf(position: number): number {
@@ -133,6 +154,20 @@ class PorterManifestASTParser {
             startLine: this.lineOf(start),
             endLine: this.lineOf(end)
         };
+    }
+
+    private rangeOf(node: YAMLNode): Range {
+        const [start, end] = this.trimmedRangeOf(node);
+        return new Range(
+            this.positionOf(start),
+            this.positionOf(end)
+        );
+    }
+
+    private positionOf(position: number): Position {
+        const lineIndex = this.lineOf(position);
+        const lineStart = this.lineStartPositions[lineIndex];
+        return new Position(lineIndex, position - lineStart);
     }
 
     private trimmedRangeOf(node: YAMLNode): [number, number] {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -8,14 +8,25 @@ export function definedOf<T>(...items: (T | undefined)[]): T[] {
 
 declare global {
     interface Array<T> {
-        filterAsync<T>(fn: (t: T) => Thenable<boolean>): Promise<T[]>;
+        choose<U>(fn: (t: T) => U | undefined): U[];
+        filterAsync(fn: (t: T) => Thenable<boolean>): Promise<T[]>;
     }
+}
+function choose<T, U>(this: T[], fn: (t: T) => U | undefined): U[] {
+    return this.map(fn).filter((u) => u !== undefined).map((u) => u!);
 }
 
 async function filterAsync<T>(this: T[], fn: (t: T) => Thenable<boolean>): Promise<T[]> {
     const filterablePromises = this.map((o) => ({ accept: fn(o), value: o }));
     const filterables = await Promise.all(filterablePromises);
     return filterables.filter((o) => o.accept).map((o) => o.value);
+}
+
+if (!Array.prototype.choose) {
+    Object.defineProperty(Array.prototype, 'choose', {
+        enumerable: false,
+        value: choose
+    });
 }
 
 if (!Array.prototype.filterAsync) {

--- a/src/utils/manifestselection.ts
+++ b/src/utils/manifestselection.ts
@@ -41,6 +41,6 @@ async function porterFolders(): Promise<readonly string[]> {
         return [];
     }
 
-    const matches = await folders.filterAsync<vscode.WorkspaceFolder>(async (f) => await fs.exists(path.join(f.uri.fsPath, 'porter.yaml')));
+    const matches = await folders.filterAsync(async (f) => await fs.exists(path.join(f.uri.fsPath, 'porter.yaml')));
     return matches.map((f) => f.uri.fsPath);
 }


### PR DESCRIPTION
This implements VS Code _Go to Definition_ support for parameters, credentials and outputs.  You can hit F12 within a reference (`{{ ... }}`) or Ctrl+Click on a reference, and it will take you to wherever the thing is defined (parameters section, credentials section, or outputs section of the action you're in).

You can also Ctrl+Hover to peek at the definition without going there, though VS Code is a bit iffy about the formatting, and includes more trailing material than I'd really like - I think this is a VS Code 'trying to be helpful by showing you context' issue though. 