### PR TITLE
Completions for references

### DIFF
--- a/src/completion/variablescompletion.ts
+++ b/src/completion/variablescompletion.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+
+import * as ast from '../porter/ast';
+import { usableVariablesAt } from '../porter/semanticmodel';
+
+export function create(): vscode.CompletionItemProvider {
+    return new PorterVariablesCompletionProvider();
+}
+
+export const COMPLETION_TRIGGERS = ['b', '.'] as const;
+
+class PorterVariablesCompletionProvider implements vscode.CompletionItemProvider {
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
+        const lineText = document.lineAt(position.line).text;
+        const beforeText = lineText.substr(0, position.character);  // NOTE: includes the trigger character
+        const templateStartIndex = beforeText.lastIndexOf('{{');
+        if (templateStartIndex < 0) {
+            return undefined;
+        }
+
+        const textToComplete = beforeText.substr(templateStartIndex + 2).trim();
+
+        // Plan:
+        // * Assemble all possible candidates (all usable variable texts)
+        // * Bung in 'bundle' and 'bundle.{x for x in var_types where there_are_any}' at the top of the list
+        // * Filter to the ones that start with the textToComplete
+        //
+        // This plan doesn't work because bundle.pa + accept bundle.parameters.foo => bundle.bundle.parameters.foo
+        // So we also need to prune completed prefixes back to the last trigger character.
+
+        const manifest = ast.parse(document.getText());
+        if (!manifest) {
+            return undefined;
+        }
+
+        const variables = usableVariablesAt(manifest, position.line).map((v) => v.text);
+        const candidates = ['bundle', 'bundle.parameters', 'bundle.credentials', 'bundle.outputs'].concat(variables);  // TODO: remove categories that don't have any members
+        const viableCandidates = candidates.filter((c) => c.startsWith(textToComplete))
+                                           .map((c) => removeCompletedPrefixes(c, textToComplete));
+
+        return viableCandidates.map((c) => new vscode.CompletionItem(c, vscode.CompletionItemKind.Reference));
+    }
+}
+
+function removeCompletedPrefixes(completionText: string, textToComplete: string): string {
+    // We know that completionText starts with textToComplete
+    const separatorIndex = textToComplete.lastIndexOf('.');
+    if (separatorIndex < 0) {
+        return completionText;
+    }
+    return completionText.substr(separatorIndex + 1);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,18 +19,20 @@ import * as definitionprovider from './navigation/definitionprovider';
 import * as referenceprovider from './navigation/referenceprovider';
 import * as diagnostics from './diagnostics/diagnostics';
 import * as codeactionprovider from './diagnostics/codeactionprovider';
+import * as variablescompletionprovider from './completion/variablescompletion';
 
 const PORTER_OUTPUT_CHANNEL = vscode.window.createOutputChannel('Porter');
 
 export async function activate(context: vscode.ExtensionContext) {
     const definitionProvider = definitionprovider.create();
     const referenceProvider = referenceprovider.create();
+    const variablesCompletionProvider = variablescompletionprovider.create();
     const codeActionProvider = codeactionprovider.create();
 
     const debugConfigurationProvider = new PorterInstallConfigurationProvider();
     const debugFactory = new PorterInstallDebugAdapterDescriptorFactory();
 
-    const porterManifestSelector = { language: 'yaml', pattern: '**/porter.yaml' };
+    const porterManifestSelector = { language: 'yaml', scheme: 'file', pattern: '**/porter.yaml' };
 
     const subscriptions = [
         vscode.commands.registerCommand('porter.createProject', createProject),
@@ -42,6 +44,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('porter.parameterise', parameteriseSelection),
         vscode.languages.registerDefinitionProvider(porterManifestSelector, definitionProvider),
         vscode.languages.registerReferenceProvider(porterManifestSelector, referenceProvider),
+        vscode.languages.registerCompletionItemProvider(porterManifestSelector, variablesCompletionProvider, ...variablescompletionprovider.COMPLETION_TRIGGERS),
         vscode.languages.registerCodeActionsProvider(porterManifestSelector, codeActionProvider, { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }),
         vscode.debug.registerDebugConfigurationProvider('porter', debugConfigurationProvider),
         vscode.debug.registerDebugAdapterDescriptorFactory('porter', debugFactory),

--- a/src/porter/semanticmodel.ts
+++ b/src/porter/semanticmodel.ts
@@ -1,0 +1,44 @@
+import * as ast from './ast';
+
+export interface UsableVariable {
+    readonly text: string;
+    readonly usableFromLine?: number;
+    readonly usableToLine?: number;
+}
+
+export function anyUsableAt(lineIndex: number, usable: UsableVariable[]): boolean {
+    return usable.some((v) => usableAt(lineIndex, v));
+}
+
+export function usableAt(lineIndex: number, variable: UsableVariable): boolean {
+    if (variable.usableFromLine && variable.usableToLine) {
+        return variable.usableFromLine <= lineIndex && lineIndex <= variable.usableToLine;
+    }
+    return true;
+}
+
+export function usableVariablesAt(manifest: ast.PorterManifestYAML, lineIndex: number): readonly UsableVariable[] {
+    return Array.of(...usableVariables(manifest)).filter((v) => usableAt(lineIndex, v));
+}
+
+export function* usableVariables(manifest: ast.PorterManifestYAML): IterableIterator<UsableVariable> {
+    if (manifest.parameters) {
+        for (const e of manifest.parameters.entries) {
+            yield { text: `bundle.parameters.${e.name}` };
+        }
+    }
+
+    if (manifest.credentials) {
+        for (const e of manifest.credentials.entries) {
+            yield { text: `bundle.credentials.${e.name}` };
+        }
+    }
+
+    for (const a of manifest.actions) {
+        for (const s of a.steps) {
+            for (const o of s.outputs) {
+                yield { text: `bundle.outputs.${o.name}`, usableFromLine: s.endLine, usableToLine: a.endLine };
+            }
+        }
+    }
+}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -9,11 +9,17 @@ export function definedOf<T>(...items: (T | undefined)[]): T[] {
 declare global {
     interface Array<T> {
         choose<U>(fn: (t: T) => U | undefined): U[];
+        distinct(): T[];
         filterAsync(fn: (t: T) => Thenable<boolean>): Promise<T[]>;
     }
 }
 function choose<T, U>(this: T[], fn: (t: T) => U | undefined): U[] {
     return this.map(fn).filter((u) => u !== undefined).map((u) => u!);
+}
+
+function distinct<T>(this: T[]): T[] {
+    const values = new Set<T>(this).values();
+    return Array.of(...values);
 }
 
 async function filterAsync<T>(this: T[], fn: (t: T) => Thenable<boolean>): Promise<T[]> {
@@ -26,6 +32,13 @@ if (!Array.prototype.choose) {
     Object.defineProperty(Array.prototype, 'choose', {
         enumerable: false,
         value: choose
+    });
+}
+
+if (!Array.prototype.distinct) {
+    Object.defineProperty(Array.prototype, 'distinct', {
+        enumerable: false,
+        value: distinct
     });
 }
 


### PR DESCRIPTION
This PR provides auto completion suggestions for expressions of the form `{{ b...` e.g.

* `bundle`
* `bundle.parameters`
* `bundle.parameters.whatever`

This currently includes commits from #34, because we use some of the same AST/semantic model stuff; once that is merged, I will rebase this and it will get a lot simpler.