### PR TITLE
Command telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ If you have the Porter binary but it's not on your path, you can specify the fil
 using the `vscode-porter > porter-path` configuration setting.  This must include the
 full file path, not just the directory (and must include the `.exe` extension on Windows).
 
+## Telemetry
+
+This extension collects telemetry data to help us build a better experience for building
+bundles with Porter and VS Code. We only collect the following data:
+
+* Which commands are executed
+
+We do not collect any information about image names, paths, etc. The extension respects
+the `telemetry.enableTelemetry` setting which you can learn more about in our
+[FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This extension collects telemetry data to help us build a better experience for 
 bundles with Porter and VS Code. We only collect the following data:
 
 * Which commands are executed
+* Whether a command succeeded or failed
 
-We do not collect any information about image names, paths, etc. The extension respects
+We do not collect any information about image names, paths, error messages, etc. The extension respects
 the `telemetry.enableTelemetry` setting which you can learn more about in our
 [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,17 @@
                 "buffer-equal": "^1.0.0"
             }
         },
+        "applicationinsights": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
+            "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+            "requires": {
+                "cls-hooked": "^4.2.2",
+                "continuation-local-storage": "^3.2.1",
+                "diagnostic-channel": "0.2.0",
+                "diagnostic-channel-publishers": "^0.3.2"
+            }
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -200,6 +211,23 @@
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
+        },
+        "async-hook-jl": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+            "requires": {
+                "stack-chain": "^1.3.7"
+            }
+        },
+        "async-listener": {
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+            "requires": {
+                "semver": "^5.3.0",
+                "shimmer": "^1.1.0"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -378,6 +406,16 @@
                 "readable-stream": "^2.3.5"
             }
         },
+        "cls-hooked": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+            "requires": {
+                "async-hook-jl": "^1.7.6",
+                "emitter-listener": "^1.0.1",
+                "semver": "^5.4.1"
+            }
+        },
         "cnabjs": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/cnabjs/-/cnabjs-0.0.5.tgz",
@@ -433,6 +471,15 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "continuation-local-storage": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+            "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.1.1"
+            }
         },
         "convert-source-map": {
             "version": "1.6.0",
@@ -491,6 +538,19 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "diagnostic-channel": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "diagnostic-channel-publishers": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
+            "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+        },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -523,6 +583,14 @@
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
+            }
+        },
+        "emitter-listener": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+            "requires": {
+                "shimmer": "^1.2.0"
             }
         },
         "end-of-stream": {
@@ -1631,8 +1699,7 @@
         "semver": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-            "dev": true
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "shelljs": {
             "version": "0.8.3",
@@ -1643,6 +1710,11 @@
                 "interpret": "^1.0.0",
                 "rechoir": "^0.6.2"
             }
+        },
+        "shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -1691,6 +1763,11 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             }
+        },
+        "stack-chain": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
         },
         "stat-mode": {
             "version": "0.2.2",
@@ -2104,6 +2181,14 @@
             "version": "1.37.0",
             "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.37.0.tgz",
             "integrity": "sha512-ppZLEBbFRVNsK0YpfgFi/x2CDyihx0F+UpdKmgeJcvi05UgSXYdO0n9sDVYwoGvvYQPvlpDQeWuY0nloOC4mPA=="
+        },
+        "vscode-extension-telemetry": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
+            "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+            "requires": {
+                "applicationinsights": "1.4.0"
+            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
         "shelljs": "^0.8.3",
         "tmp": "^0.0.33",
         "vscode-debugadapter": "^1.37.1",
+        "vscode-extension-telemetry": "^0.1.2",
         "yaml-ast-parser": "0.0.43"
     },
     "devDependencies": {

--- a/src/commands/result.ts
+++ b/src/commands/result.ts
@@ -1,0 +1,15 @@
+import { Errorable, succeeded } from "../utils/errorable";
+
+export enum CommandResult {
+    Unknown = 0,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+export function commandResultOf<T>(errorable: Errorable<T>): CommandResult {
+    if (succeeded(errorable)) {
+        return CommandResult.Succeeded;
+    }
+    return CommandResult.Failed;
+}

--- a/src/telemetry/telemetry-helper.ts
+++ b/src/telemetry/telemetry-helper.ts
@@ -1,10 +1,20 @@
+import * as vscode from 'vscode';
 import { reporter } from './telemetry';
 
-export function telemetrise(command: string, callback: (...args: any[]) => any): (...args: any[]) => any {
-    return (a) => {
+export function telemetriseCommand(command: string, callback: (...args: any[]) => any): (...args: any[]) => any {
+    return (args) => {
         if (reporter) {
             reporter.sendTelemetryEvent("command", { command: command });
         }
-        return callback(a);
+        return callback(args);
+    };
+}
+
+export function telemetriseTextEditorCommand(command: string, callback: (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => any): (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => any {
+    return (textEditor, edit, args) => {
+        if (reporter) {
+            reporter.sendTelemetryEvent("command", { command: command });
+        }
+        return callback(textEditor, edit, args);
     };
 }

--- a/src/telemetry/telemetry-helper.ts
+++ b/src/telemetry/telemetry-helper.ts
@@ -1,0 +1,10 @@
+import { reporter } from './telemetry';
+
+export function telemetrise(command: string, callback: (...args: any[]) => any): (...args: any[]) => any {
+    return (a) => {
+        if (reporter) {
+            reporter.sendTelemetryEvent("command", { command: command });
+        }
+        return callback(a);
+    };
+}

--- a/src/telemetry/telemetry-helper.ts
+++ b/src/telemetry/telemetry-helper.ts
@@ -1,20 +1,52 @@
 import * as vscode from 'vscode';
 import { reporter } from './telemetry';
+import { CommandResult } from '../commands/result';
 
-export function telemetriseCommand(command: string, callback: (...args: any[]) => any): (...args: any[]) => any {
+export function telemetriseCommand(command: string, callback: (...args: any[]) => CommandResult | Promise<CommandResult>): (...args: any[]) => CommandResult | Promise<CommandResult> {
     return (args) => {
         if (reporter) {
             reporter.sendTelemetryEvent("command", { command: command });
         }
-        return callback(args);
+        const commandResult = callback(args);
+        when(commandResult, (r) => reportResult(command, r));
+        return commandResult;
     };
 }
 
-export function telemetriseTextEditorCommand(command: string, callback: (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => any): (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => any {
+export function telemetriseTextEditorCommand(command: string, callback: (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => CommandResult | Promise<CommandResult>): (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => CommandResult | Promise<CommandResult> {
     return (textEditor, edit, args) => {
         if (reporter) {
             reporter.sendTelemetryEvent("command", { command: command });
         }
-        return callback(textEditor, edit, args);
+        const commandResult = callback(textEditor, edit, args);
+        when(commandResult, (r) => reportResult(command, r));
+        return commandResult;
     };
+}
+
+function thenable<T>(t: T | Thenable<T>): t is Thenable<T> {
+    return !!((t as any).then);
+}
+
+function when<T>(value: T | Thenable<T>, fn: (t: T) => void): void {
+    if (thenable(value)) {
+        value.then((v) => fn(v));
+    } else {
+        fn(value);
+    }
+}
+
+function reportResult(command: string, result: CommandResult) {
+    if (reporter) {
+        reporter.sendTelemetryEvent("commandResult", { command: command, succeeded: commandResultText(result) });
+    }
+}
+
+function commandResultText(result: CommandResult): string {
+    switch (result) {
+        case CommandResult.Unknown: return 'unknown';
+        case CommandResult.Succeeded: return 'succeeded';
+        case CommandResult.Failed: return 'failed';
+        case CommandResult.Cancelled: return 'cancelled';
+    }
 }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,0 +1,32 @@
+import TelemetryReporter from 'vscode-extension-telemetry';
+import vscode = require('vscode');
+
+export let reporter: TelemetryReporter | undefined;
+
+export class Reporter extends vscode.Disposable {
+
+    constructor(ctx: vscode.ExtensionContext) {
+        super(() => { if (reporter) { reporter.dispose(); } });
+        const packageInfo = getPackageInfo(ctx);
+        reporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+
+    }
+}
+
+interface IPackageInfo {
+    name: string;
+    version: string;
+    aiKey: string;
+}
+
+function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo | undefined {
+    const extensionPackage = require(context.asAbsolutePath('./package.json'));
+    if (extensionPackage) {
+        return {
+            name: extensionPackage.name,
+            version: extensionPackage.version,
+            aiKey: extensionPackage.aiKey
+        };
+    }
+    return undefined;
+}


### PR DESCRIPTION
Provides telemetry on which commands are used per the disclosure in the readme.

I can't see a way to get telemetry on things like Go To Definition or autocompletion.  And I am not sure that I can get telemetry on quick fixes or wiggles that is meaningful, because these can be invoked even if the user never takes and interest in them.